### PR TITLE
Fix build process

### DIFF
--- a/build.py
+++ b/build.py
@@ -3,7 +3,6 @@ import glob
 import os
 import platform
 import shutil
-import stat
 import subprocess
 
 try:
@@ -14,7 +13,7 @@ except ImportError:
 
 _BAZEL_BIN_PATH = 'bazel-bin'
 _BUILD_PATH = 'build'
-_INSTALL_PATH = os.path.join('Packages', 'com.github.homuler.mediapipe', 'Runtime')
+_INSTALL_PATH = os.path.join('src', 'Akihabara')
 
 class Console:
   def __init__(self, verbose):
@@ -94,8 +93,8 @@ class BuildCommand(Command):
 
     self.system = platform.system()
     self.desktop = command_args.args.desktop
-    self.android = command_args.args.android
-    self.ios= command_args.args.ios
+    # self.android = command_args.args.android
+    # self.ios= command_args.args.ios
     self.resources = command_args.args.resources
     self.opencv = command_args.args.opencv
     self.opencv_deps = command_args.args.opencv_deps
@@ -103,44 +102,50 @@ class BuildCommand(Command):
 
     self.compilation_mode = command_args.args.compilation_mode
     self.linkopt = command_args.args.linkopt
+    self.protobuf = command_args.args.protobuf
 
   def run(self):
-    self.console.info('Building protobuf sources...')
-    self._run_command(self._build_proto_srcs_commands())
-    self._unzip(
-      os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'mediapipe_proto_srcs.zip'),
-      os.path.join('src', 'Akihabara', 'Framework', 'Protobuf'))
-    self.console.info('Built protobuf sources')
+    if self.protobuf:
+      self.console.info('Building protobuf sources...')
+      self._run_command(self._build_proto_srcs_commands())
+      self._unzip(
+        os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'mediapipe_proto_srcs.zip'),
+        os.path.join(_BUILD_PATH, 'Framework', 'Protobuf'))
+      self.console.info('Built protobuf sources')
 
+    # # Unity-specific requirements, not needed for .NET
+    # self.console.info('Downloading protobuf dlls...')
+    # self._run_command(self._build_proto_dlls_commands())
+    # for f in glob.glob(os.path.join('.nuget', '**', 'lib', 'netstandard2.0', '*.dll'), recursive=True):
+    #   basename = os.path.basename(f)
+    #   self._copy(f, os.path.join(_BUILD_PATH, 'Plugins', 'Protobuf', basename))
+    # self.console.info('Downloaded protobuf dlls')
 
-    # if self.resources:
-    #   self.console.info('Building resource files')
-    #   self._run_command(self._build_resources_commands())
-    #   self._unzip(
-    #     os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'mediapipe_assets.zip'),
-    #     os.path.join(_BUILD_PATH, 'Resources'))
+    if self.resources:
+      self.console.info('Building resource files')
+      self._run_command(self._build_resources_commands())
+      self._unzip(
+        os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'mediapipe_assets.zip'),
+        os.path.join(_BUILD_PATH, 'Resources'))
+      self.console.info('Built resource files')
 
-    #   self.console.info('Built resource files')
+    if self.desktop:
+      self.console.info('Building native libraries for Desktop...')
+      self._run_command(self._build_desktop_commands())
+      self._unzip(
+        os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'mediapipe_desktop.zip'),
+        os.path.join(_BUILD_PATH, 'bin', 'Debug', 'net5.0'))
 
+      if self.include_opencv_libs:
+        if self.opencv == 'cmake':
+          self.console.warn('OpenCV objects are included in libmediapipe_c, so skip copying OpenCV library files')
+        else:
+          self._run_command(self._build_opencv_libs())
+          self._unzip(
+            os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'opencv_libs.zip'),
+            os.path.join(_BUILD_PATH, 'bin', 'Debug', 'net5.0', 'opencv'))
 
-    # if self.desktop:
-    #   self.console.info('Building native libraries for Desktop...')
-    #   self._run_command(self._build_desktop_commands())
-    #   self._unzip(
-    #     os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'mediapipe_desktop.zip'),
-    #     os.path.join(_BUILD_PATH, 'Plugins'))
-
-    #   if self.include_opencv_libs:
-    #     if self.opencv == 'cmake':
-    #       self.console.warn('OpenCV objects are included in libmediapipe_c, so skip copying OpenCV library files')
-    #     else:
-    #       self._run_command(self._build_opencv_libs())
-    #       self._unzip(
-    #         os.path.join(_BAZEL_BIN_PATH, 'mediapipe_api', 'opencv_libs.zip'),
-    #         os.path.join(_BUILD_PATH, 'Plugins', 'OpenCV'))
-
-    #   self.console.info('Built native libraries for Desktop')
-
+      self.console.info('Built native libraries for Desktop')
 
     # if self.android:
     #   self.console.info('Building native libraries for Android...')
@@ -151,7 +156,6 @@ class BuildCommand(Command):
 
     #   self.console.info('Built native libraries for Android')
 
-
     # if self.ios:
     #   self.console.info('Building native libaries for iOS...')
     #   self._run_command(self._build_ios_commands())
@@ -161,11 +165,10 @@ class BuildCommand(Command):
 
     #   self.console.info('Built native libraries for iOS')
 
-
     # self.console.info('Installing...')
     # # _copytree fails on Windows, so run `cp -r` instead.
     # self._copytree(_BUILD_PATH, _INSTALL_PATH)
-    self.console.info('Installed')
+    # self.console.info('Installed')
 
   def _is_windows(self):
     return self.system == 'Windows'
@@ -238,23 +241,23 @@ class BuildCommand(Command):
 
     return commands
 
-  def _build_android_commands(self):
-    if self.android is None:
-      return []
+  # def _build_android_commands(self):
+  #   if self.android is None:
+  #     return []
 
-    commands = self._build_common_commands()
-    commands.append(f'--config=android_{self.android}')
-    commands.append('//mediapipe_api/java/com/github/homuler/mediapipe:mediapipe_android')
-    return commands
+  #   commands = self._build_common_commands()
+  #   commands.append(f'--config=android_{self.android}')
+  #   commands.append('//mediapipe_api/java/com/github/homuler/mediapipe:mediapipe_android')
+  #   return commands
 
-  def _build_ios_commands(self):
-    if self.ios is None:
-      return []
+  # def _build_ios_commands(self):
+  #   if self.ios is None:
+  #     return []
 
-    commands = self._build_common_commands()
-    commands += [f'--config=ios_{self.ios}', '--copt=-fembed-bitcode', '--apple_bitcode=embedded']
-    commands.append('//mediapipe_api/objc:MediaPipeUnity')
-    return commands
+  #   commands = self._build_common_commands()
+  #   commands += [f'--config=ios_{self.ios}', '--copt=-fembed-bitcode', '--apple_bitcode=embedded']
+  #   commands.append('//mediapipe_api/objc:MediaPipeUnity')
+  #   return commands
 
   def _build_resources_commands(self):
     if not self.resources:
@@ -269,6 +272,8 @@ class BuildCommand(Command):
     commands.append('//mediapipe_api:mediapipe_proto_srcs')
     return commands
 
+  # def _build_proto_dlls_commands(self):
+  #   return ['nuget', 'install', '-o', '.nuget', '-Source', 'https://api.nuget.org/v3/index.json']
 
 
 class CleanCommand(Command):
@@ -348,10 +353,11 @@ class Argument:
     subparsers = self.argument_parser.add_subparsers(dest='command')
 
     build_command_parser = subparsers.add_parser('build', help='Build and install native libraries')
-    build_command_parser.add_argument('--desktop', choices=['cpu', 'gpu'])
-    build_command_parser.add_argument('--android', choices=['arm', 'arm64'])
-    build_command_parser.add_argument('--ios', choices=['arm64'])
-    build_command_parser.add_argument('--resources', action=argparse.BooleanOptionalAction, default=True)
+    build_command_parser.add_argument('--protobuf', '-p', action=argparse.BooleanOptionalAction, help='Build C# protobuf sources for Akihabara')
+    build_command_parser.add_argument('--desktop', '-d', choices=['cpu', 'gpu'])
+    # build_command_parser.add_argument('--android', '-a', choices=['arm', 'arm64'])
+    # build_command_parser.add_argument('--ios', '-i', choices=['arm64'])
+    build_command_parser.add_argument('--resources', '-R', action=argparse.BooleanOptionalAction)
     build_command_parser.add_argument('--compilation_mode', '-c', choices=['fastbuild', 'opt', 'dbg'], default='opt')
     build_command_parser.add_argument('--opencv', choices=['local', 'cmake'], default='local', help='Decide to which OpenCV to link for Desktop native libraries')
     build_command_parser.add_argument('--opencv_deps', action='append', choices=['ffmpeg'], default=[], help='OpenCV Dependencies (only used when `--opencv=cmake`)')
@@ -364,8 +370,8 @@ class Argument:
 
     uninstall_command_parser = subparsers.add_parser('uninstall', help='Uninstall native libraries')
     uninstall_command_parser.add_argument('--desktop', action=argparse.BooleanOptionalAction, default=True)
-    uninstall_command_parser.add_argument('--android', action=argparse.BooleanOptionalAction, default=True)
-    uninstall_command_parser.add_argument('--ios', action=argparse.BooleanOptionalAction, default=True)
+    # uninstall_command_parser.add_argument('--android', action=argparse.BooleanOptionalAction, default=True)
+    # uninstall_command_parser.add_argument('--ios', action=argparse.BooleanOptionalAction, default=True)
     uninstall_command_parser.add_argument('--resources', action=argparse.BooleanOptionalAction, default=True)
     uninstall_command_parser.add_argument('--protobuf', action=argparse.BooleanOptionalAction, default=True)
     uninstall_command_parser.add_argument('--verbose', '-v', action='count', default=0)

--- a/third_party/proto_namespace.diff
+++ b/third_party/proto_namespace.diff
@@ -1,2656 +1,2460 @@
 diff --git a/mediapipe/calculators/audio/mfcc_mel_calculators.proto b/mediapipe/calculators/audio/mfcc_mel_calculators.proto
-index 89af5eb..7b0ebcc 100644
+index 89af5eb..0004db7 100644
 --- a/mediapipe/calculators/audio/mfcc_mel_calculators.proto
 +++ b/mediapipe/calculators/audio/mfcc_mel_calculators.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/audio/rational_factor_resample_calculator.proto b/mediapipe/calculators/audio/rational_factor_resample_calculator.proto
-index 97d7f20..8e3e03a 100644
+index 97d7f20..bc555f2 100644
 --- a/mediapipe/calculators/audio/rational_factor_resample_calculator.proto
 +++ b/mediapipe/calculators/audio/rational_factor_resample_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/audio/spectrogram_calculator.proto b/mediapipe/calculators/audio/spectrogram_calculator.proto
-index b721117..3321660 100644
+index b721117..30297f9 100644
 --- a/mediapipe/calculators/audio/spectrogram_calculator.proto
 +++ b/mediapipe/calculators/audio/spectrogram_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/audio/stabilized_log_calculator.proto b/mediapipe/calculators/audio/stabilized_log_calculator.proto
-index ef6faa8..2580a02 100644
+index ef6faa8..8114b32 100644
 --- a/mediapipe/calculators/audio/stabilized_log_calculator.proto
 +++ b/mediapipe/calculators/audio/stabilized_log_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/audio/time_series_framer_calculator.proto b/mediapipe/calculators/audio/time_series_framer_calculator.proto
-index 9e5b074..5004eb5 100644
+index 9e5b074..d0c1408 100644
 --- a/mediapipe/calculators/audio/time_series_framer_calculator.proto
 +++ b/mediapipe/calculators/audio/time_series_framer_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/clip_vector_size_calculator.proto b/mediapipe/calculators/core/clip_vector_size_calculator.proto
-index 6044f77..4533e39 100644
+index 6044f77..ecebf0a 100644
 --- a/mediapipe/calculators/core/clip_vector_size_calculator.proto
 +++ b/mediapipe/calculators/core/clip_vector_size_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/concatenate_vector_calculator.proto b/mediapipe/calculators/core/concatenate_vector_calculator.proto
-index 3753ffb..38e497a 100644
+index 3753ffb..886cf98 100644
 --- a/mediapipe/calculators/core/concatenate_vector_calculator.proto
 +++ b/mediapipe/calculators/core/concatenate_vector_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/constant_side_packet_calculator.proto b/mediapipe/calculators/core/constant_side_packet_calculator.proto
-index 57f5dc5..e2e9ef5 100644
+index 57f5dc5..990828d 100644
 --- a/mediapipe/calculators/core/constant_side_packet_calculator.proto
 +++ b/mediapipe/calculators/core/constant_side_packet_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/framework/formats/classification.proto";
 diff --git a/mediapipe/calculators/core/dequantize_byte_array_calculator.proto b/mediapipe/calculators/core/dequantize_byte_array_calculator.proto
-index 3af8e11..139385c 100644
+index 3af8e11..d1b7fd2 100644
 --- a/mediapipe/calculators/core/dequantize_byte_array_calculator.proto
 +++ b/mediapipe/calculators/core/dequantize_byte_array_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/flow_limiter_calculator.proto b/mediapipe/calculators/core/flow_limiter_calculator.proto
-index 0f7c925..f3b6339 100644
+index 0f7c925..1864252 100644
 --- a/mediapipe/calculators/core/flow_limiter_calculator.proto
 +++ b/mediapipe/calculators/core/flow_limiter_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/gate_calculator.proto b/mediapipe/calculators/core/gate_calculator.proto
-index 76bacc7..de40590 100644
+index 76bacc7..7ab3d54 100644
 --- a/mediapipe/calculators/core/gate_calculator.proto
 +++ b/mediapipe/calculators/core/gate_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/packet_cloner_calculator.proto b/mediapipe/calculators/core/packet_cloner_calculator.proto
-index e30672f..efa364e 100644
+index e30672f..5c29fb2 100644
 --- a/mediapipe/calculators/core/packet_cloner_calculator.proto
 +++ b/mediapipe/calculators/core/packet_cloner_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/packet_resampler_calculator.proto b/mediapipe/calculators/core/packet_resampler_calculator.proto
-index f7ca470..ff6399c 100644
+index f7ca470..ee53161 100644
 --- a/mediapipe/calculators/core/packet_resampler_calculator.proto
 +++ b/mediapipe/calculators/core/packet_resampler_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/packet_thinner_calculator.proto b/mediapipe/calculators/core/packet_thinner_calculator.proto
-index 6c69f3a..bb4780a 100644
+index 6c69f3a..5d659d3 100644
 --- a/mediapipe/calculators/core/packet_thinner_calculator.proto
 +++ b/mediapipe/calculators/core/packet_thinner_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/quantize_float_vector_calculator.proto b/mediapipe/calculators/core/quantize_float_vector_calculator.proto
-index 0ccc3c0..2e0cd85 100644
+index 0ccc3c0..ce0b393 100644
 --- a/mediapipe/calculators/core/quantize_float_vector_calculator.proto
 +++ b/mediapipe/calculators/core/quantize_float_vector_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/sequence_shift_calculator.proto b/mediapipe/calculators/core/sequence_shift_calculator.proto
-index cdcd284..4acecec 100644
+index cdcd284..074ae2b 100644
 --- a/mediapipe/calculators/core/sequence_shift_calculator.proto
 +++ b/mediapipe/calculators/core/sequence_shift_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/split_vector_calculator.proto b/mediapipe/calculators/core/split_vector_calculator.proto
-index 40301f8..d5869da 100644
+index 40301f8..771a0c0 100644
 --- a/mediapipe/calculators/core/split_vector_calculator.proto
 +++ b/mediapipe/calculators/core/split_vector_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/bilateral_filter_calculator.proto b/mediapipe/calculators/image/bilateral_filter_calculator.proto
-index a787437..74f791d 100644
+index a787437..b535bb3 100644
 --- a/mediapipe/calculators/image/bilateral_filter_calculator.proto
 +++ b/mediapipe/calculators/image/bilateral_filter_calculator.proto
-@@ -1,7 +1,7 @@
- // Options for BilateralFilterCalculator
+@@ -2,6 +2,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/feature_detector_calculator.proto b/mediapipe/calculators/image/feature_detector_calculator.proto
-index 7bff235..d5a8906 100644
+index 7bff235..2afca89 100644
 --- a/mediapipe/calculators/image/feature_detector_calculator.proto
 +++ b/mediapipe/calculators/image/feature_detector_calculator.proto
-@@ -1,7 +1,7 @@
- // Options for FeatureDetectorCalculator
+@@ -2,6 +2,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/image_clone_calculator.proto b/mediapipe/calculators/image/image_clone_calculator.proto
-index 6fa05dc..7172652 100644
+index 6fa05dc..d881032 100644
 --- a/mediapipe/calculators/image/image_clone_calculator.proto
 +++ b/mediapipe/calculators/image/image_clone_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/image_cropping_calculator.proto b/mediapipe/calculators/image/image_cropping_calculator.proto
-index 55d3467..b674664 100644
+index 55d3467..12bd61d 100644
 --- a/mediapipe/calculators/image/image_cropping_calculator.proto
 +++ b/mediapipe/calculators/image/image_cropping_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/image_transformation_calculator.proto b/mediapipe/calculators/image/image_transformation_calculator.proto
-index c90e03b..f343152 100644
+index c90e03b..f3b0ff0 100644
 --- a/mediapipe/calculators/image/image_transformation_calculator.proto
 +++ b/mediapipe/calculators/image/image_transformation_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/gpu/scale_mode.proto";
 diff --git a/mediapipe/calculators/image/mask_overlay_calculator.proto b/mediapipe/calculators/image/mask_overlay_calculator.proto
-index 3b82d61..2522f7d 100644
+index 3b82d61..d95a28a 100644
 --- a/mediapipe/calculators/image/mask_overlay_calculator.proto
 +++ b/mediapipe/calculators/image/mask_overlay_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/opencv_encoded_image_to_image_frame_calculator.proto b/mediapipe/calculators/image/opencv_encoded_image_to_image_frame_calculator.proto
-index 3ec29bd..385f839 100644
+index 3ec29bd..afb274f 100644
 --- a/mediapipe/calculators/image/opencv_encoded_image_to_image_frame_calculator.proto
 +++ b/mediapipe/calculators/image/opencv_encoded_image_to_image_frame_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/opencv_image_encoder_calculator.proto b/mediapipe/calculators/image/opencv_image_encoder_calculator.proto
-index 0564fb2..e234bde 100644
+index 0564fb2..8d7eba6 100644
 --- a/mediapipe/calculators/image/opencv_image_encoder_calculator.proto
 +++ b/mediapipe/calculators/image/opencv_image_encoder_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/recolor_calculator.proto b/mediapipe/calculators/image/recolor_calculator.proto
-index abbf084..fbeb15b 100644
+index abbf084..ef79172 100644
 --- a/mediapipe/calculators/image/recolor_calculator.proto
 +++ b/mediapipe/calculators/image/recolor_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/calculators/image/scale_image_calculator.proto b/mediapipe/calculators/image/scale_image_calculator.proto
-index e51ccaf..34a85f3 100644
+index e51ccaf..f028119 100644
 --- a/mediapipe/calculators/image/scale_image_calculator.proto
 +++ b/mediapipe/calculators/image/scale_image_calculator.proto
-@@ -1,7 +1,7 @@
- // Options for ScaleImageCalculator.
+@@ -2,6 +2,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/framework/formats/image_format.proto";
 diff --git a/mediapipe/calculators/image/segmentation_smoothing_calculator.proto b/mediapipe/calculators/image/segmentation_smoothing_calculator.proto
-index 12b10cc..10ce186 100644
+index 12b10cc..110fed6 100644
 --- a/mediapipe/calculators/image/segmentation_smoothing_calculator.proto
 +++ b/mediapipe/calculators/image/segmentation_smoothing_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/image/set_alpha_calculator.proto b/mediapipe/calculators/image/set_alpha_calculator.proto
-index 3f07ddb..5a4dbdd 100644
+index 3f07ddb..dd6143b 100644
 --- a/mediapipe/calculators/image/set_alpha_calculator.proto
 +++ b/mediapipe/calculators/image/set_alpha_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/internal/callback_packet_calculator.proto b/mediapipe/calculators/internal/callback_packet_calculator.proto
-index 6a5cfb0..10c95ca 100644
+index 6a5cfb0..7abd1df 100644
 --- a/mediapipe/calculators/internal/callback_packet_calculator.proto
 +++ b/mediapipe/calculators/internal/callback_packet_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/image_to_tensor_calculator.proto b/mediapipe/calculators/tensor/image_to_tensor_calculator.proto
-index 0451dc5..b4898d4 100644
+index 0451dc5..d9919ea 100644
 --- a/mediapipe/calculators/tensor/image_to_tensor_calculator.proto
 +++ b/mediapipe/calculators/tensor/image_to_tensor_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/gpu/gpu_origin.proto";
 diff --git a/mediapipe/calculators/tensor/inference_calculator.proto b/mediapipe/calculators/tensor/inference_calculator.proto
-index e0b538a..ef74c46 100644
+index e0b538a..98d2031 100644
 --- a/mediapipe/calculators/tensor/inference_calculator.proto
 +++ b/mediapipe/calculators/tensor/inference_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/tensor_converter_calculator.proto b/mediapipe/calculators/tensor/tensor_converter_calculator.proto
-index 97c2154..b69268d 100644
+index 97c2154..3c65ea6 100644
 --- a/mediapipe/calculators/tensor/tensor_converter_calculator.proto
 +++ b/mediapipe/calculators/tensor/tensor_converter_calculator.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto b/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto
-index 3934a61..1d9f35a 100644
+index 3934a61..785a3b2 100644
 --- a/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto
 +++ b/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto b/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto
-index 364eb5c..edde036 100644
+index 364eb5c..8c82b3f 100644
 --- a/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto
 +++ b/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/tensors_to_floats_calculator.proto b/mediapipe/calculators/tensor/tensors_to_floats_calculator.proto
-index 6940501..84a9bd3 100644
+index 6940501..dfac450 100644
 --- a/mediapipe/calculators/tensor/tensors_to_floats_calculator.proto
 +++ b/mediapipe/calculators/tensor/tensors_to_floats_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/tensors_to_landmarks_calculator.proto b/mediapipe/calculators/tensor/tensors_to_landmarks_calculator.proto
-index 2608a14..dd343f5 100644
+index 2608a14..a9852ac 100644
 --- a/mediapipe/calculators/tensor/tensors_to_landmarks_calculator.proto
 +++ b/mediapipe/calculators/tensor/tensors_to_landmarks_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.proto b/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.proto
-index 1662576..14bde09 100644
+index 1662576..2febc65 100644
 --- a/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.proto
 +++ b/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/gpu/gpu_origin.proto";
 diff --git a/mediapipe/calculators/tensorflow/graph_tensors_packet_generator.proto b/mediapipe/calculators/tensorflow/graph_tensors_packet_generator.proto
-index 1196ca1..9bcce4a 100644
+index 1196ca1..3a13e6c 100644
 --- a/mediapipe/calculators/tensorflow/graph_tensors_packet_generator.proto
 +++ b/mediapipe/calculators/tensorflow/graph_tensors_packet_generator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/packet_generator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/image_frame_to_tensor_calculator.proto b/mediapipe/calculators/tensorflow/image_frame_to_tensor_calculator.proto
-index 0e5a477..ec6c751 100644
+index 0e5a477..ae595f6 100644
 --- a/mediapipe/calculators/tensorflow/image_frame_to_tensor_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/image_frame_to_tensor_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "tensorflow/core/framework/types.proto";
 diff --git a/mediapipe/calculators/tensorflow/lapped_tensor_buffer_calculator.proto b/mediapipe/calculators/tensorflow/lapped_tensor_buffer_calculator.proto
-index bcd1498..8e21606 100644
+index bcd1498..03bae44 100644
 --- a/mediapipe/calculators/tensorflow/lapped_tensor_buffer_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/lapped_tensor_buffer_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/matrix_to_tensor_calculator_options.proto b/mediapipe/calculators/tensorflow/matrix_to_tensor_calculator_options.proto
-index 50a1775..bbd6e92 100644
+index 50a1775..ed3ea07 100644
 --- a/mediapipe/calculators/tensorflow/matrix_to_tensor_calculator_options.proto
 +++ b/mediapipe/calculators/tensorflow/matrix_to_tensor_calculator_options.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/object_detection_tensors_to_detections_calculator.proto b/mediapipe/calculators/tensorflow/object_detection_tensors_to_detections_calculator.proto
-index 1491446..375137a 100644
+index 1491446..b6d24a1 100644
 --- a/mediapipe/calculators/tensorflow/object_detection_tensors_to_detections_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/object_detection_tensors_to_detections_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/pack_media_sequence_calculator.proto b/mediapipe/calculators/tensorflow/pack_media_sequence_calculator.proto
-index 695eb6b..bb60f84 100644
+index 695eb6b..d064835 100644
 --- a/mediapipe/calculators/tensorflow/pack_media_sequence_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/pack_media_sequence_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "tensorflow/core/example/feature.proto";
 diff --git a/mediapipe/calculators/tensorflow/tensor_squeeze_dimensions_calculator.proto b/mediapipe/calculators/tensorflow/tensor_squeeze_dimensions_calculator.proto
-index 87c5978..e8d9ec3 100644
+index 87c5978..689c5e8 100644
 --- a/mediapipe/calculators/tensorflow/tensor_squeeze_dimensions_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/tensor_squeeze_dimensions_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/tensor_to_image_frame_calculator.proto b/mediapipe/calculators/tensorflow/tensor_to_image_frame_calculator.proto
-index 3410068..55b3d2b 100644
+index 3410068..da03e51 100644
 --- a/mediapipe/calculators/tensorflow/tensor_to_image_frame_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/tensor_to_image_frame_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/tensor_to_matrix_calculator.proto b/mediapipe/calculators/tensorflow/tensor_to_matrix_calculator.proto
-index e864770..3dcb937 100644
+index e864770..fda96e9 100644
 --- a/mediapipe/calculators/tensorflow/tensor_to_matrix_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/tensor_to_matrix_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/framework/formats/time_series_header.proto";
 diff --git a/mediapipe/calculators/tensorflow/tensor_to_vector_float_calculator_options.proto b/mediapipe/calculators/tensorflow/tensor_to_vector_float_calculator_options.proto
-index c9aa67f..659d4e1 100644
+index c9aa67f..e737240 100644
 --- a/mediapipe/calculators/tensorflow/tensor_to_vector_float_calculator_options.proto
 +++ b/mediapipe/calculators/tensorflow/tensor_to_vector_float_calculator_options.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/tensorflow_inference_calculator.proto b/mediapipe/calculators/tensorflow/tensorflow_inference_calculator.proto
-index 98dbd5b..230d797 100644
+index 98dbd5b..819f951 100644
 --- a/mediapipe/calculators/tensorflow/tensorflow_inference_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/tensorflow_inference_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.proto b/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.proto
-index 87b2304..e509513 100644
+index 87b2304..00061c2 100644
 --- a/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "tensorflow/core/protobuf/config.proto";
 diff --git a/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_generator.proto b/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_generator.proto
-index 4643b4d..f95b782 100644
+index 4643b4d..74c6791 100644
 --- a/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_generator.proto
 +++ b/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_generator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/packet_generator.proto";
  import "tensorflow/core/protobuf/config.proto";
 diff --git a/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_calculator.proto b/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_calculator.proto
-index 927d3b5..f06d3aa 100644
+index 927d3b5..d710495 100644
 --- a/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "tensorflow/core/protobuf/config.proto";
 diff --git a/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_generator.proto b/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_generator.proto
-index d24a1cd..5fcc72f 100644
+index d24a1cd..1255915 100644
 --- a/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_generator.proto
 +++ b/mediapipe/calculators/tensorflow/tensorflow_session_from_saved_model_generator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/packet_generator.proto";
  import "tensorflow/core/protobuf/config.proto";
 diff --git a/mediapipe/calculators/tensorflow/unpack_media_sequence_calculator.proto b/mediapipe/calculators/tensorflow/unpack_media_sequence_calculator.proto
-index 51cc870..97292b1 100644
+index 51cc870..d2f0778 100644
 --- a/mediapipe/calculators/tensorflow/unpack_media_sequence_calculator.proto
 +++ b/mediapipe/calculators/tensorflow/unpack_media_sequence_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/calculators/core/packet_resampler_calculator.proto";
  import "mediapipe/framework/calculator.proto";
 diff --git a/mediapipe/calculators/tensorflow/vector_float_to_tensor_calculator_options.proto b/mediapipe/calculators/tensorflow/vector_float_to_tensor_calculator_options.proto
-index 01be3b7..2b3c0d2 100644
+index 01be3b7..7e06d49 100644
 --- a/mediapipe/calculators/tensorflow/vector_float_to_tensor_calculator_options.proto
 +++ b/mediapipe/calculators/tensorflow/vector_float_to_tensor_calculator_options.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensorflow/vector_int_to_tensor_calculator_options.proto b/mediapipe/calculators/tensorflow/vector_int_to_tensor_calculator_options.proto
-index 65554bb..7fbde3e 100644
+index 65554bb..51c7f48 100644
 --- a/mediapipe/calculators/tensorflow/vector_int_to_tensor_calculator_options.proto
 +++ b/mediapipe/calculators/tensorflow/vector_int_to_tensor_calculator_options.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "tensorflow/core/framework/types.proto";
 diff --git a/mediapipe/calculators/tensorflow/vector_string_to_tensor_calculator_options.proto b/mediapipe/calculators/tensorflow/vector_string_to_tensor_calculator_options.proto
-index 908d98d..11ae8de 100644
+index 908d98d..821c078 100644
 --- a/mediapipe/calculators/tensorflow/vector_string_to_tensor_calculator_options.proto
 +++ b/mediapipe/calculators/tensorflow/vector_string_to_tensor_calculator_options.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/ssd_anchors_calculator.proto b/mediapipe/calculators/tflite/ssd_anchors_calculator.proto
-index c892488..ab14efb 100644
+index c892488..78d4f73 100644
 --- a/mediapipe/calculators/tflite/ssd_anchors_calculator.proto
 +++ b/mediapipe/calculators/tflite/ssd_anchors_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/tflite_converter_calculator.proto b/mediapipe/calculators/tflite/tflite_converter_calculator.proto
-index 5ed7087..8826714 100644
+index 5ed7087..0634dfe 100644
 --- a/mediapipe/calculators/tflite/tflite_converter_calculator.proto
 +++ b/mediapipe/calculators/tflite/tflite_converter_calculator.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/tflite_custom_op_resolver_calculator.proto b/mediapipe/calculators/tflite/tflite_custom_op_resolver_calculator.proto
-index 546165a..af04d95 100644
+index 546165a..e24cb86 100644
 --- a/mediapipe/calculators/tflite/tflite_custom_op_resolver_calculator.proto
 +++ b/mediapipe/calculators/tflite/tflite_custom_op_resolver_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/tflite_inference_calculator.proto b/mediapipe/calculators/tflite/tflite_inference_calculator.proto
-index 02dc208..05c01e1 100644
+index 02dc208..7141516 100644
 --- a/mediapipe/calculators/tflite/tflite_inference_calculator.proto
 +++ b/mediapipe/calculators/tflite/tflite_inference_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/tflite_tensors_to_classification_calculator.proto b/mediapipe/calculators/tflite/tflite_tensors_to_classification_calculator.proto
-index c6c9d91..1afcab1 100644
+index c6c9d91..4bb468e 100644
 --- a/mediapipe/calculators/tflite/tflite_tensors_to_classification_calculator.proto
 +++ b/mediapipe/calculators/tflite/tflite_tensors_to_classification_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/tflite_tensors_to_detections_calculator.proto b/mediapipe/calculators/tflite/tflite_tensors_to_detections_calculator.proto
-index ef494c2..b813af3 100644
+index ef494c2..0fc4d55 100644
 --- a/mediapipe/calculators/tflite/tflite_tensors_to_detections_calculator.proto
 +++ b/mediapipe/calculators/tflite/tflite_tensors_to_detections_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/tflite_tensors_to_landmarks_calculator.proto b/mediapipe/calculators/tflite/tflite_tensors_to_landmarks_calculator.proto
-index 793639a..2d2c026 100644
+index 793639a..8e91b0f 100644
 --- a/mediapipe/calculators/tflite/tflite_tensors_to_landmarks_calculator.proto
 +++ b/mediapipe/calculators/tflite/tflite_tensors_to_landmarks_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.proto b/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.proto
-index d04aa56..9aa2a47 100644
+index d04aa56..d68e986 100644
 --- a/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.proto
 +++ b/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/annotation_overlay_calculator.proto b/mediapipe/calculators/util/annotation_overlay_calculator.proto
-index 339bb21..dfd6442 100644
+index 339bb21..9a00d07 100644
 --- a/mediapipe/calculators/util/annotation_overlay_calculator.proto
 +++ b/mediapipe/calculators/util/annotation_overlay_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/calculators/util/association_calculator.proto b/mediapipe/calculators/util/association_calculator.proto
-index ca66f80..393da1c 100644
+index ca66f80..cc75cc1 100644
 --- a/mediapipe/calculators/util/association_calculator.proto
 +++ b/mediapipe/calculators/util/association_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/collection_has_min_size_calculator.proto b/mediapipe/calculators/util/collection_has_min_size_calculator.proto
-index f482277..8565954 100644
+index f482277..06718ce 100644
 --- a/mediapipe/calculators/util/collection_has_min_size_calculator.proto
 +++ b/mediapipe/calculators/util/collection_has_min_size_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto b/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto
-index 198ca4d..277ed83 100644
+index 198ca4d..8c36a3f 100644
 --- a/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto
 +++ b/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/detections_to_rects_calculator.proto b/mediapipe/calculators/util/detections_to_rects_calculator.proto
-index d49eb6c..4396c4d 100644
+index d49eb6c..f7de0e4 100644
 --- a/mediapipe/calculators/util/detections_to_rects_calculator.proto
 +++ b/mediapipe/calculators/util/detections_to_rects_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/detections_to_render_data_calculator.proto b/mediapipe/calculators/util/detections_to_render_data_calculator.proto
-index acc847d..1dfd755 100644
+index acc847d..32cc23f 100644
 --- a/mediapipe/calculators/util/detections_to_render_data_calculator.proto
 +++ b/mediapipe/calculators/util/detections_to_render_data_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/calculators/util/labels_to_render_data_calculator.proto b/mediapipe/calculators/util/labels_to_render_data_calculator.proto
-index c5012ce..26c50bc 100644
+index c5012ce..44628e2 100644
 --- a/mediapipe/calculators/util/labels_to_render_data_calculator.proto
 +++ b/mediapipe/calculators/util/labels_to_render_data_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/calculators/util/landmark_projection_calculator.proto b/mediapipe/calculators/util/landmark_projection_calculator.proto
-index 221adbe..58079a2 100644
+index 221adbe..428695f 100644
 --- a/mediapipe/calculators/util/landmark_projection_calculator.proto
 +++ b/mediapipe/calculators/util/landmark_projection_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/landmarks_smoothing_calculator.proto b/mediapipe/calculators/util/landmarks_smoothing_calculator.proto
-index 017facb..0b738b9 100644
+index 017facb..392e346 100644
 --- a/mediapipe/calculators/util/landmarks_smoothing_calculator.proto
 +++ b/mediapipe/calculators/util/landmarks_smoothing_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator_options.proto";
  
 diff --git a/mediapipe/calculators/util/landmarks_to_detection_calculator.proto b/mediapipe/calculators/util/landmarks_to_detection_calculator.proto
-index b5a5636..441d202 100644
+index b5a5636..72dcbaf 100644
 --- a/mediapipe/calculators/util/landmarks_to_detection_calculator.proto
 +++ b/mediapipe/calculators/util/landmarks_to_detection_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/landmarks_to_floats_calculator.proto b/mediapipe/calculators/util/landmarks_to_floats_calculator.proto
-index 310251e..a28b5e9 100644
+index 310251e..18a8b6d 100644
 --- a/mediapipe/calculators/util/landmarks_to_floats_calculator.proto
 +++ b/mediapipe/calculators/util/landmarks_to_floats_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/landmarks_to_render_data_calculator.proto b/mediapipe/calculators/util/landmarks_to_render_data_calculator.proto
-index 9909195..5abc8e0 100644
+index 9909195..5b1a004 100644
 --- a/mediapipe/calculators/util/landmarks_to_render_data_calculator.proto
 +++ b/mediapipe/calculators/util/landmarks_to_render_data_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/calculators/util/latency.proto b/mediapipe/calculators/util/latency.proto
-index 4b122fb..de4a289 100644
+index 4b122fb..c49ddce 100644
 --- a/mediapipe/calculators/util/latency.proto
 +++ b/mediapipe/calculators/util/latency.proto
-@@ -1,7 +1,7 @@
- // Proto messages related to latency measurement for Soapbox.
+@@ -2,6 +2,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Contains the latency information for a packet stream in mediapipe. The
  // following are provided
 diff --git a/mediapipe/calculators/util/local_file_contents_calculator.proto b/mediapipe/calculators/util/local_file_contents_calculator.proto
-index 17876c8..bfec2ab 100644
+index 17876c8..81ec478 100644
 --- a/mediapipe/calculators/util/local_file_contents_calculator.proto
 +++ b/mediapipe/calculators/util/local_file_contents_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/logic_calculator.proto b/mediapipe/calculators/util/logic_calculator.proto
-index fe00a2d..8b8a4f3 100644
+index fe00a2d..232c1b0 100644
 --- a/mediapipe/calculators/util/logic_calculator.proto
 +++ b/mediapipe/calculators/util/logic_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/non_max_suppression_calculator.proto b/mediapipe/calculators/util/non_max_suppression_calculator.proto
-index 5fa9604..7ea76f6 100644
+index 5fa9604..00badcb 100644
 --- a/mediapipe/calculators/util/non_max_suppression_calculator.proto
 +++ b/mediapipe/calculators/util/non_max_suppression_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/packet_frequency.proto b/mediapipe/calculators/util/packet_frequency.proto
-index 177a73b..8c14cd3 100644
+index 177a73b..ee39def 100644
 --- a/mediapipe/calculators/util/packet_frequency.proto
 +++ b/mediapipe/calculators/util/packet_frequency.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Contains the packet frequency information.
  message PacketFrequency {
 diff --git a/mediapipe/calculators/util/packet_frequency_calculator.proto b/mediapipe/calculators/util/packet_frequency_calculator.proto
-index e7be1c4..9e515fb 100644
+index e7be1c4..cafa6ac 100644
 --- a/mediapipe/calculators/util/packet_frequency_calculator.proto
 +++ b/mediapipe/calculators/util/packet_frequency_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/packet_latency_calculator.proto b/mediapipe/calculators/util/packet_latency_calculator.proto
-index 63ec5f9..50d3306 100644
+index 63ec5f9..a4b2f36 100644
 --- a/mediapipe/calculators/util/packet_latency_calculator.proto
 +++ b/mediapipe/calculators/util/packet_latency_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/rect_to_render_data_calculator.proto b/mediapipe/calculators/util/rect_to_render_data_calculator.proto
-index 9b6d5e6..8034484 100644
+index 9b6d5e6..e5e8bf0 100644
 --- a/mediapipe/calculators/util/rect_to_render_data_calculator.proto
 +++ b/mediapipe/calculators/util/rect_to_render_data_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/calculators/util/rect_to_render_scale_calculator.proto b/mediapipe/calculators/util/rect_to_render_scale_calculator.proto
-index dda6e2c..b1268ec 100644
+index dda6e2c..9715db2 100644
 --- a/mediapipe/calculators/util/rect_to_render_scale_calculator.proto
 +++ b/mediapipe/calculators/util/rect_to_render_scale_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/rect_transformation_calculator.proto b/mediapipe/calculators/util/rect_transformation_calculator.proto
-index 44e781d..c2af0cd 100644
+index 44e781d..964a08f 100644
 --- a/mediapipe/calculators/util/rect_transformation_calculator.proto
 +++ b/mediapipe/calculators/util/rect_transformation_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/refine_landmarks_from_heatmap_calculator.proto b/mediapipe/calculators/util/refine_landmarks_from_heatmap_calculator.proto
-index eebcaed..927059f 100644
+index eebcaed..2cc72a1 100644
 --- a/mediapipe/calculators/util/refine_landmarks_from_heatmap_calculator.proto
 +++ b/mediapipe/calculators/util/refine_landmarks_from_heatmap_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/thresholding_calculator.proto b/mediapipe/calculators/util/thresholding_calculator.proto
-index b8d81ad..0a4a35a 100644
+index b8d81ad..62967c7 100644
 --- a/mediapipe/calculators/util/thresholding_calculator.proto
 +++ b/mediapipe/calculators/util/thresholding_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/timed_box_list_id_to_label_calculator.proto b/mediapipe/calculators/util/timed_box_list_id_to_label_calculator.proto
-index 95cf765..f30087e 100644
+index 95cf765..e03b34f 100644
 --- a/mediapipe/calculators/util/timed_box_list_id_to_label_calculator.proto
 +++ b/mediapipe/calculators/util/timed_box_list_id_to_label_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/timed_box_list_to_render_data_calculator.proto b/mediapipe/calculators/util/timed_box_list_to_render_data_calculator.proto
-index 31e1ecb..7d912a0 100644
+index 31e1ecb..af978d8 100644
 --- a/mediapipe/calculators/util/timed_box_list_to_render_data_calculator.proto
 +++ b/mediapipe/calculators/util/timed_box_list_to_render_data_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/calculators/util/top_k_scores_calculator.proto b/mediapipe/calculators/util/top_k_scores_calculator.proto
-index 08fb7a7..492425a 100644
+index 08fb7a7..ae2f1df 100644
 --- a/mediapipe/calculators/util/top_k_scores_calculator.proto
 +++ b/mediapipe/calculators/util/top_k_scores_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/visibility_copy_calculator.proto b/mediapipe/calculators/util/visibility_copy_calculator.proto
-index df25937..316cbcb 100644
+index df25937..76e48a0 100644
 --- a/mediapipe/calculators/util/visibility_copy_calculator.proto
 +++ b/mediapipe/calculators/util/visibility_copy_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator_options.proto";
  
 diff --git a/mediapipe/calculators/util/visibility_smoothing_calculator.proto b/mediapipe/calculators/util/visibility_smoothing_calculator.proto
-index 3b99192..faaf613 100644
+index 3b99192..e7cdab6 100644
 --- a/mediapipe/calculators/util/visibility_smoothing_calculator.proto
 +++ b/mediapipe/calculators/util/visibility_smoothing_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator_options.proto";
  
 diff --git a/mediapipe/calculators/video/box_detector_calculator.proto b/mediapipe/calculators/video/box_detector_calculator.proto
-index f0eb42f..ecb6c44 100644
+index f0eb42f..f150292 100644
 --- a/mediapipe/calculators/video/box_detector_calculator.proto
 +++ b/mediapipe/calculators/video/box_detector_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/tracking/box_detector.proto";
 diff --git a/mediapipe/calculators/video/box_tracker_calculator.proto b/mediapipe/calculators/video/box_tracker_calculator.proto
-index 2001082..033c9ca 100644
+index 2001082..694d313 100644
 --- a/mediapipe/calculators/video/box_tracker_calculator.proto
 +++ b/mediapipe/calculators/video/box_tracker_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/tracking/box_tracker.proto";
 diff --git a/mediapipe/calculators/video/flow_packager_calculator.proto b/mediapipe/calculators/video/flow_packager_calculator.proto
-index c1e91d8..aaae16c 100644
+index c1e91d8..11adce4 100644
 --- a/mediapipe/calculators/video/flow_packager_calculator.proto
 +++ b/mediapipe/calculators/video/flow_packager_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/tracking/flow_packager.proto";
 diff --git a/mediapipe/calculators/video/flow_to_image_calculator.proto b/mediapipe/calculators/video/flow_to_image_calculator.proto
-index 6d5fb84..1922265 100644
+index 6d5fb84..926efef 100644
 --- a/mediapipe/calculators/video/flow_to_image_calculator.proto
 +++ b/mediapipe/calculators/video/flow_to_image_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/video/motion_analysis_calculator.proto b/mediapipe/calculators/video/motion_analysis_calculator.proto
-index a2af77d..a0b256a 100644
+index a2af77d..fb48ff5 100644
 --- a/mediapipe/calculators/video/motion_analysis_calculator.proto
 +++ b/mediapipe/calculators/video/motion_analysis_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/tracking/motion_analysis.proto";
 diff --git a/mediapipe/calculators/video/opencv_video_encoder_calculator.proto b/mediapipe/calculators/video/opencv_video_encoder_calculator.proto
-index a3a7af3..7912038 100644
+index a3a7af3..db07b33 100644
 --- a/mediapipe/calculators/video/opencv_video_encoder_calculator.proto
 +++ b/mediapipe/calculators/video/opencv_video_encoder_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/video/tool/flow_quantizer_model.proto b/mediapipe/calculators/video/tool/flow_quantizer_model.proto
-index 02f3fc1..32f8c80 100644
+index 02f3fc1..fe1738b 100644
 --- a/mediapipe/calculators/video/tool/flow_quantizer_model.proto
 +++ b/mediapipe/calculators/video/tool/flow_quantizer_model.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Message storing min value and max value for normalization in all channels.
  message QuantizerModelData {
 diff --git a/mediapipe/calculators/video/tracked_detection_manager_calculator.proto b/mediapipe/calculators/video/tracked_detection_manager_calculator.proto
-index 4462425..0a2fe2a 100644
+index 4462425..1f115ef 100644
 --- a/mediapipe/calculators/video/tracked_detection_manager_calculator.proto
 +++ b/mediapipe/calculators/video/tracked_detection_manager_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/tracking/tracked_detection_manager_config.proto";
 diff --git a/mediapipe/calculators/video/video_pre_stream_calculator.proto b/mediapipe/calculators/video/video_pre_stream_calculator.proto
-index 8e87ce9..3ddee2d 100644
+index 8e87ce9..609c1dd 100644
 --- a/mediapipe/calculators/video/video_pre_stream_calculator.proto
 +++ b/mediapipe/calculators/video/video_pre_stream_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/examples/desktop/autoflip/autoflip_messages.proto b/mediapipe/examples/desktop/autoflip/autoflip_messages.proto
-index 726237e..41f0add 100644
+index 726237e..041755a 100644
 --- a/mediapipe/examples/desktop/autoflip/autoflip_messages.proto
 +++ b/mediapipe/examples/desktop/autoflip/autoflip_messages.proto
-@@ -15,7 +15,7 @@
- // Proto messages used for the AutoFlip Pipeline.
+@@ -16,6 +16,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/border_detection_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/border_detection_calculator.proto
-index 9be74a3..165c409 100644
+index 9be74a3..ec8d8f0 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/border_detection_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/border_detection_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/content_zooming_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/content_zooming_calculator.proto
-index 6516ed2..410d40d 100644
+index 6516ed2..1942701 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/content_zooming_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/content_zooming_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/examples/desktop/autoflip/quality/kinematic_path_solver.proto";
  import "mediapipe/framework/calculator.proto";
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/face_box_adjuster_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/face_box_adjuster_calculator.proto
-index 1a4a1c6..7dc1f4a 100644
+index 1a4a1c6..16dc43c 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/face_box_adjuster_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/face_box_adjuster_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/face_to_region_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/face_to_region_calculator.proto
-index 86e4c31..f92ef7a 100644
+index 86e4c31..807cabf 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/face_to_region_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/face_to_region_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/examples/desktop/autoflip/quality/visual_scorer.proto";
  import "mediapipe/framework/calculator.proto";
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/localization_to_region_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/localization_to_region_calculator.proto
-index 1dd00ac..ee218df 100644
+index 1dd00ac..7fcdab4 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/localization_to_region_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/localization_to_region_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/scene_cropping_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/scene_cropping_calculator.proto
-index f9ba9cb..e4368e1 100644
+index f9ba9cb..34ec0c0 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/scene_cropping_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/scene_cropping_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/examples/desktop/autoflip/quality/cropping.proto";
  import "mediapipe/framework/calculator.proto";
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/shot_boundary_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/shot_boundary_calculator.proto
-index b0f3bd9..0199c33 100644
+index b0f3bd9..657b41d 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/shot_boundary_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/shot_boundary_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/signal_fusing_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/signal_fusing_calculator.proto
-index 3f14935..4ff0a66 100644
+index 3f14935..5cac99e 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/signal_fusing_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/signal_fusing_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/examples/desktop/autoflip/autoflip_messages.proto";
  import "mediapipe/framework/calculator.proto";
 diff --git a/mediapipe/examples/desktop/autoflip/calculators/video_filtering_calculator.proto b/mediapipe/examples/desktop/autoflip/calculators/video_filtering_calculator.proto
-index 997696a..16dcc57 100644
+index 997696a..3154d4f 100644
 --- a/mediapipe/examples/desktop/autoflip/calculators/video_filtering_calculator.proto
 +++ b/mediapipe/examples/desktop/autoflip/calculators/video_filtering_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/examples/desktop/autoflip/quality/cropping.proto b/mediapipe/examples/desktop/autoflip/quality/cropping.proto
-index f8a62b2..83b9aa4 100644
+index f8a62b2..50667a0 100644
 --- a/mediapipe/examples/desktop/autoflip/quality/cropping.proto
 +++ b/mediapipe/examples/desktop/autoflip/quality/cropping.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  import "mediapipe/examples/desktop/autoflip/autoflip_messages.proto";
  import "mediapipe/examples/desktop/autoflip/quality/kinematic_path_solver.proto";
 diff --git a/mediapipe/examples/desktop/autoflip/quality/focus_point.proto b/mediapipe/examples/desktop/autoflip/quality/focus_point.proto
-index e53b3ed..5e382d8 100644
+index e53b3ed..051a809 100644
 --- a/mediapipe/examples/desktop/autoflip/quality/focus_point.proto
 +++ b/mediapipe/examples/desktop/autoflip/quality/focus_point.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  // Focus point location (normalized w.r.t. frame_width and frame_height, i.e.
  // specified in the domain [0, 1] x [0, 1]).
 diff --git a/mediapipe/examples/desktop/autoflip/quality/kinematic_path_solver.proto b/mediapipe/examples/desktop/autoflip/quality/kinematic_path_solver.proto
-index 9f481db..99a6cec 100644
+index 9f481db..ccf05fc 100644
 --- a/mediapipe/examples/desktop/autoflip/quality/kinematic_path_solver.proto
 +++ b/mediapipe/examples/desktop/autoflip/quality/kinematic_path_solver.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  message KinematicOptions {
    // Weighted update of new camera velocity (measurement) vs current state
 diff --git a/mediapipe/examples/desktop/autoflip/quality/visual_scorer.proto b/mediapipe/examples/desktop/autoflip/quality/visual_scorer.proto
-index 4623e1e..7673b90 100644
+index 4623e1e..eae08f9 100644
 --- a/mediapipe/examples/desktop/autoflip/quality/visual_scorer.proto
 +++ b/mediapipe/examples/desktop/autoflip/quality/visual_scorer.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.autoflip;
-+package akihabara.framework.protobuf.autoflip;
+ package mediapipe.autoflip;
++option csharp_namespace = "Akihabara.Framework.Protobuf.AutoFlip";
  
  // Options for the VisualScorer module.
  // Next tag: 6
 diff --git a/mediapipe/framework/calculator.proto b/mediapipe/framework/calculator.proto
-index b39b95a..5e0cd7b 100644
+index b39b95a..dd4d1b7 100644
 --- a/mediapipe/framework/calculator.proto
 +++ b/mediapipe/framework/calculator.proto
-@@ -17,7 +17,7 @@
- // ONLY used by mediapipe open source project.
+@@ -18,6 +18,7 @@
  syntax = "proto3";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import public "mediapipe/framework/calculator_options.proto";
  
 diff --git a/mediapipe/framework/calculator_contract_test.proto b/mediapipe/framework/calculator_contract_test.proto
-index d86d99f..cedb2cd 100644
+index d86d99f..10e2282 100644
 --- a/mediapipe/framework/calculator_contract_test.proto
 +++ b/mediapipe/framework/calculator_contract_test.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/framework/calculator_options.proto b/mediapipe/framework/calculator_options.proto
-index 747e9c4..8ba3aa5 100644
+index 747e9c4..cc2cf92 100644
 --- a/mediapipe/framework/calculator_options.proto
 +++ b/mediapipe/framework/calculator_options.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.proto";
  option java_outer_classname = "CalculatorOptionsProto";
 diff --git a/mediapipe/framework/calculator_profile.proto b/mediapipe/framework/calculator_profile.proto
-index 723178a..61f4a46 100644
+index 723178a..28d7198 100644
 --- a/mediapipe/framework/calculator_profile.proto
 +++ b/mediapipe/framework/calculator_profile.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/framework/deps/proto_descriptor.proto b/mediapipe/framework/deps/proto_descriptor.proto
-index 77762df..e91f664 100644
+index 77762df..89361b1 100644
 --- a/mediapipe/framework/deps/proto_descriptor.proto
 +++ b/mediapipe/framework/deps/proto_descriptor.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Describes a field within a message.
  message FieldDescriptorProto {
 diff --git a/mediapipe/framework/formats/annotation/locus.proto b/mediapipe/framework/formats/annotation/locus.proto
-index a079cca..e1dda21 100644
+index a079cca..86a03ef 100644
 --- a/mediapipe/framework/formats/annotation/locus.proto
 +++ b/mediapipe/framework/formats/annotation/locus.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/formats/annotation/rasterization.proto";
  
 diff --git a/mediapipe/framework/formats/annotation/rasterization.proto b/mediapipe/framework/formats/annotation/rasterization.proto
-index 38414df..227c03d 100644
+index 38414df..4bac219 100644
 --- a/mediapipe/framework/formats/annotation/rasterization.proto
 +++ b/mediapipe/framework/formats/annotation/rasterization.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.formats.annotation.proto";
  option java_outer_classname = "RasterizationProto";
 diff --git a/mediapipe/framework/formats/classification.proto b/mediapipe/framework/formats/classification.proto
-index dbe079f..d429244 100644
+index dbe079f..19299f6 100644
 --- a/mediapipe/framework/formats/classification.proto
 +++ b/mediapipe/framework/formats/classification.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option objc_class_prefix = "MediaPipe";
  option java_package = "com.google.mediapipe.formats.proto";
 diff --git a/mediapipe/framework/formats/detection.proto b/mediapipe/framework/formats/detection.proto
-index 3e2d067..946640f 100644
+index 3e2d067..76e64f7 100644
 --- a/mediapipe/framework/formats/detection.proto
 +++ b/mediapipe/framework/formats/detection.proto
-@@ -20,7 +20,7 @@
- 
+@@ -21,6 +21,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/formats/location_data.proto";
  
 diff --git a/mediapipe/framework/formats/image_file_properties.proto b/mediapipe/framework/formats/image_file_properties.proto
-index 0d3cd62..1212174 100644
+index 0d3cd62..04d0cb0 100644
 --- a/mediapipe/framework/formats/image_file_properties.proto
 +++ b/mediapipe/framework/formats/image_file_properties.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // A list of properties extracted from EXIF metadata from an image file.
  message ImageFileProperties {
 diff --git a/mediapipe/framework/formats/image_format.proto b/mediapipe/framework/formats/image_format.proto
-index 4bedb8c..41729ba 100644
+index 4bedb8c..b4d114b 100644
 --- a/mediapipe/framework/formats/image_format.proto
 +++ b/mediapipe/framework/formats/image_format.proto
-@@ -21,7 +21,7 @@
- 
+@@ -22,6 +22,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message ImageFormat {
    enum Format {
 diff --git a/mediapipe/framework/formats/landmark.proto b/mediapipe/framework/formats/landmark.proto
-index eb6a454..63fc3cb 100644
+index eb6a454..07dc086 100644
 --- a/mediapipe/framework/formats/landmark.proto
 +++ b/mediapipe/framework/formats/landmark.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.formats.proto";
  option java_outer_classname = "LandmarkProto";
 diff --git a/mediapipe/framework/formats/location_data.proto b/mediapipe/framework/formats/location_data.proto
-index 3edd542..64b12e6 100644
+index 3edd542..73dd844 100644
 --- a/mediapipe/framework/formats/location_data.proto
 +++ b/mediapipe/framework/formats/location_data.proto
-@@ -19,7 +19,7 @@
- 
+@@ -20,6 +20,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/formats/annotation/rasterization.proto";
  
 diff --git a/mediapipe/framework/formats/matrix_data.proto b/mediapipe/framework/formats/matrix_data.proto
-index d4aa457..10370c4 100644
+index d4aa457..2dbe08c 100644
 --- a/mediapipe/framework/formats/matrix_data.proto
 +++ b/mediapipe/framework/formats/matrix_data.proto
-@@ -19,7 +19,7 @@
- 
+@@ -20,6 +20,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.formats.proto";
  option java_outer_classname = "MatrixDataProto";
 diff --git a/mediapipe/framework/formats/motion/optical_flow_field_data.proto b/mediapipe/framework/formats/motion/optical_flow_field_data.proto
-index c2dda97..3147bb2 100644
+index c2dda97..f076370 100644
 --- a/mediapipe/framework/formats/motion/optical_flow_field_data.proto
 +++ b/mediapipe/framework/formats/motion/optical_flow_field_data.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message OpticalFlowFieldData {
    optional int32 width = 1;
 diff --git a/mediapipe/framework/formats/object_detection/anchor.proto b/mediapipe/framework/formats/object_detection/anchor.proto
-index 8eeed48..70e3e57 100644
+index 8eeed48..9eb87a2 100644
 --- a/mediapipe/framework/formats/object_detection/anchor.proto
 +++ b/mediapipe/framework/formats/object_detection/anchor.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // The anchor representation for object detection.
  message Anchor {
 diff --git a/mediapipe/framework/formats/rect.proto b/mediapipe/framework/formats/rect.proto
-index 6b57a4a..e3ef10c 100644
+index 6b57a4a..4645027 100644
 --- a/mediapipe/framework/formats/rect.proto
 +++ b/mediapipe/framework/formats/rect.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.formats.proto";
  option java_outer_classname = "RectProto";
 diff --git a/mediapipe/framework/formats/time_series_header.proto b/mediapipe/framework/formats/time_series_header.proto
-index a16f47d..96cec2a 100644
+index a16f47d..9910441 100644
 --- a/mediapipe/framework/formats/time_series_header.proto
 +++ b/mediapipe/framework/formats/time_series_header.proto
-@@ -19,7 +19,7 @@
- 
+@@ -20,6 +20,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Header for a uniformly sampled time series stream. Each Packet in
  // the stream is a Matrix, and each column is a (vector-valued) sample of
 diff --git a/mediapipe/framework/mediapipe_options.proto b/mediapipe/framework/mediapipe_options.proto
-index 0ded959..1e7c3d2 100644
+index 0ded959..9a2b2cf 100644
 --- a/mediapipe/framework/mediapipe_options.proto
 +++ b/mediapipe/framework/mediapipe_options.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.proto";
  option java_outer_classname = "MediaPipeOptionsProto";
 diff --git a/mediapipe/framework/packet_factory.proto b/mediapipe/framework/packet_factory.proto
-index 518097f..3006415 100644
+index 518097f..94e292c 100644
 --- a/mediapipe/framework/packet_factory.proto
 +++ b/mediapipe/framework/packet_factory.proto
-@@ -20,7 +20,7 @@
- 
+@@ -21,6 +21,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Options used by a PacketFactory to create the Packet.
  message PacketFactoryOptions {
 diff --git a/mediapipe/framework/packet_generator.proto b/mediapipe/framework/packet_generator.proto
-index 14f13a1..6c11730 100644
+index 14f13a1..f4c8e1f 100644
 --- a/mediapipe/framework/packet_generator.proto
 +++ b/mediapipe/framework/packet_generator.proto
-@@ -20,7 +20,7 @@
- 
+@@ -21,6 +21,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Options used by a PacketGenerator.
  message PacketGeneratorOptions {
 diff --git a/mediapipe/framework/packet_test.proto b/mediapipe/framework/packet_test.proto
-index bccfd6b..ec60f08 100644
+index bccfd6b..54ce241 100644
 --- a/mediapipe/framework/packet_test.proto
 +++ b/mediapipe/framework/packet_test.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message PacketTestProto {
    // Tests that the tags used to encode the timestamp do not interfere with
 diff --git a/mediapipe/framework/status_handler.proto b/mediapipe/framework/status_handler.proto
-index 6e7ce83..ac52bd6 100644
+index 6e7ce83..5146db2 100644
 --- a/mediapipe/framework/status_handler.proto
 +++ b/mediapipe/framework/status_handler.proto
-@@ -20,7 +20,7 @@
- 
+@@ -21,6 +21,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/stream_handler.proto b/mediapipe/framework/stream_handler.proto
-index e0731d9..e53b0fe 100644
+index e0731d9..e7c7693 100644
 --- a/mediapipe/framework/stream_handler.proto
 +++ b/mediapipe/framework/stream_handler.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/stream_handler/default_input_stream_handler.proto b/mediapipe/framework/stream_handler/default_input_stream_handler.proto
-index 11638e7..e1257ae 100644
+index 11638e7..ba75041 100644
 --- a/mediapipe/framework/stream_handler/default_input_stream_handler.proto
 +++ b/mediapipe/framework/stream_handler/default_input_stream_handler.proto
-@@ -19,7 +19,7 @@
- 
+@@ -20,6 +20,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/stream_handler/fixed_size_input_stream_handler.proto b/mediapipe/framework/stream_handler/fixed_size_input_stream_handler.proto
-index f2ce235..57843a1 100644
+index f2ce235..41e249c 100644
 --- a/mediapipe/framework/stream_handler/fixed_size_input_stream_handler.proto
 +++ b/mediapipe/framework/stream_handler/fixed_size_input_stream_handler.proto
-@@ -19,7 +19,7 @@
- 
+@@ -20,6 +20,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/stream_handler/sync_set_input_stream_handler.proto b/mediapipe/framework/stream_handler/sync_set_input_stream_handler.proto
-index 8dc4d0f..e6b8bc9 100644
+index 8dc4d0f..f7e38c1 100644
 --- a/mediapipe/framework/stream_handler/sync_set_input_stream_handler.proto
 +++ b/mediapipe/framework/stream_handler/sync_set_input_stream_handler.proto
-@@ -19,7 +19,7 @@
- 
+@@ -20,6 +20,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/stream_handler/timestamp_align_input_stream_handler.proto b/mediapipe/framework/stream_handler/timestamp_align_input_stream_handler.proto
-index cbbe297..7cf828e 100644
+index cbbe297..2af1989 100644
 --- a/mediapipe/framework/stream_handler/timestamp_align_input_stream_handler.proto
 +++ b/mediapipe/framework/stream_handler/timestamp_align_input_stream_handler.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/test_calculators.proto b/mediapipe/framework/test_calculators.proto
-index af75dc1..0f1a055 100644
+index af75dc1..05c304f 100644
 --- a/mediapipe/framework/test_calculators.proto
 +++ b/mediapipe/framework/test_calculators.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/framework/testdata/night_light_calculator.proto b/mediapipe/framework/testdata/night_light_calculator.proto
-index 3618043..fdd9e0c 100644
+index 3618043..2a31ed2 100644
 --- a/mediapipe/framework/testdata/night_light_calculator.proto
 +++ b/mediapipe/framework/testdata/night_light_calculator.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/framework/testdata/sky_light_calculator.proto b/mediapipe/framework/testdata/sky_light_calculator.proto
-index 0bf0445..d5d1d72 100644
+index 0bf0445..1490a0c 100644
 --- a/mediapipe/framework/testdata/sky_light_calculator.proto
 +++ b/mediapipe/framework/testdata/sky_light_calculator.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto3";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // A proto3 calculator options for testing.
  message SkyLightCalculatorOptions {
 diff --git a/mediapipe/framework/thread_pool_executor.proto b/mediapipe/framework/thread_pool_executor.proto
-index 50b19eb..b0324d0 100644
+index 50b19eb..de830f7 100644
 --- a/mediapipe/framework/thread_pool_executor.proto
 +++ b/mediapipe/framework/thread_pool_executor.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/tool/calculator_graph_template.proto b/mediapipe/framework/tool/calculator_graph_template.proto
-index c2fc6aa..02e232e 100644
+index c2fc6aa..b3b461d 100644
 --- a/mediapipe/framework/tool/calculator_graph_template.proto
 +++ b/mediapipe/framework/tool/calculator_graph_template.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/framework/deps/proto_descriptor.proto";
 diff --git a/mediapipe/framework/tool/node_chain_subgraph.proto b/mediapipe/framework/tool/node_chain_subgraph.proto
-index c6e8980..b19f49a 100644
+index c6e8980..f8dab49 100644
 --- a/mediapipe/framework/tool/node_chain_subgraph.proto
 +++ b/mediapipe/framework/tool/node_chain_subgraph.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/framework/tool/source.proto b/mediapipe/framework/tool/source.proto
-index 40660bb..918cff9 100644
+index 40660bb..5934856 100644
 --- a/mediapipe/framework/tool/source.proto
 +++ b/mediapipe/framework/tool/source.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/framework/tool/switch_container.proto b/mediapipe/framework/tool/switch_container.proto
-index ac39950..61351de 100644
+index ac39950..c3f7c22 100644
 --- a/mediapipe/framework/tool/switch_container.proto
 +++ b/mediapipe/framework/tool/switch_container.proto
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/gpu/copy_calculator.proto b/mediapipe/gpu/copy_calculator.proto
-index fca53e9..2e3c43c 100644
+index fca53e9..8a639a4 100644
 --- a/mediapipe/gpu/copy_calculator.proto
 +++ b/mediapipe/gpu/copy_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/gpu/gl_context_options.proto b/mediapipe/gpu/gl_context_options.proto
-index 25b82c2..722c5da 100644
+index 25b82c2..2ebc9d8 100644
 --- a/mediapipe/gpu/gl_context_options.proto
 +++ b/mediapipe/gpu/gl_context_options.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/gpu/gl_scaler_calculator.proto b/mediapipe/gpu/gl_scaler_calculator.proto
-index 99c0d43..36eaab7 100644
+index 99c0d43..263873f 100644
 --- a/mediapipe/gpu/gl_scaler_calculator.proto
 +++ b/mediapipe/gpu/gl_scaler_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/gpu/scale_mode.proto";
 diff --git a/mediapipe/gpu/gl_surface_sink_calculator.proto b/mediapipe/gpu/gl_surface_sink_calculator.proto
-index 8621908..fd47852 100644
+index 8621908..09f683d 100644
 --- a/mediapipe/gpu/gl_surface_sink_calculator.proto
 +++ b/mediapipe/gpu/gl_surface_sink_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/gpu/scale_mode.proto";
 diff --git a/mediapipe/gpu/gpu_origin.proto b/mediapipe/gpu/gpu_origin.proto
-index f4db835..2ecc48e 100644
+index f4db835..59e9838 100644
 --- a/mediapipe/gpu/gpu_origin.proto
 +++ b/mediapipe/gpu/gpu_origin.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message GpuOrigin {
    enum Mode {
 diff --git a/mediapipe/gpu/scale_mode.proto b/mediapipe/gpu/scale_mode.proto
-index ef7d7af..7a23c30 100644
+index ef7d7af..5580881 100644
 --- a/mediapipe/gpu/scale_mode.proto
 +++ b/mediapipe/gpu/scale_mode.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // We wrap the enum in a message to avoid namespace collisions.
  message ScaleMode {
 diff --git a/mediapipe/graphs/instant_motion_tracking/calculators/sticker_buffer.proto b/mediapipe/graphs/instant_motion_tracking/calculators/sticker_buffer.proto
-index b73209c..eab1f07 100644
+index b73209c..817aae7 100644
 --- a/mediapipe/graphs/instant_motion_tracking/calculators/sticker_buffer.proto
 +++ b/mediapipe/graphs/instant_motion_tracking/calculators/sticker_buffer.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.graphs.instantmotiontracking";
  option java_outer_classname = "StickerBufferProto";
 diff --git a/mediapipe/graphs/iris_tracking/calculators/iris_to_depth_calculator.proto b/mediapipe/graphs/iris_tracking/calculators/iris_to_depth_calculator.proto
-index 786cd30..9d8bb05 100644
+index 786cd30..36b89f2 100644
 --- a/mediapipe/graphs/iris_tracking/calculators/iris_to_depth_calculator.proto
 +++ b/mediapipe/graphs/iris_tracking/calculators/iris_to_depth_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/graphs/iris_tracking/calculators/iris_to_render_data_calculator.proto b/mediapipe/graphs/iris_tracking/calculators/iris_to_render_data_calculator.proto
-index e0fc677..781a021 100644
+index e0fc677..f2311fc 100644
 --- a/mediapipe/graphs/iris_tracking/calculators/iris_to_render_data_calculator.proto
 +++ b/mediapipe/graphs/iris_tracking/calculators/iris_to_render_data_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/graphs/object_detection_3d/calculators/annotations_to_model_matrices_calculator.proto b/mediapipe/graphs/object_detection_3d/calculators/annotations_to_model_matrices_calculator.proto
-index c0159d4..5466ece 100644
+index c0159d4..6a6f265 100644
 --- a/mediapipe/graphs/object_detection_3d/calculators/annotations_to_model_matrices_calculator.proto
 +++ b/mediapipe/graphs/object_detection_3d/calculators/annotations_to_model_matrices_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/graphs/object_detection_3d/calculators/annotations_to_render_data_calculator.proto b/mediapipe/graphs/object_detection_3d/calculators/annotations_to_render_data_calculator.proto
-index 1e04d95..7afaecb 100644
+index 1e04d95..f5ed8f0 100644
 --- a/mediapipe/graphs/object_detection_3d/calculators/annotations_to_render_data_calculator.proto
 +++ b/mediapipe/graphs/object_detection_3d/calculators/annotations_to_render_data_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/util/color.proto";
 diff --git a/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.proto b/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.proto
-index 4966f0a..99e3d1c 100644
+index 4966f0a..d3c96c2 100644
 --- a/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.proto
 +++ b/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/graphs/object_detection_3d/calculators/model_matrix.proto b/mediapipe/graphs/object_detection_3d/calculators/model_matrix.proto
-index 406cc9f..29217ad 100644
+index 406cc9f..94164e2 100644
 --- a/mediapipe/graphs/object_detection_3d/calculators/model_matrix.proto
 +++ b/mediapipe/graphs/object_detection_3d/calculators/model_matrix.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message TimedModelMatrixProto {
    // 4x4 model matrix stored in ROW major order.
 diff --git a/mediapipe/modules/face_geometry/effect_renderer_calculator.proto b/mediapipe/modules/face_geometry/effect_renderer_calculator.proto
-index 6c23903..6733f8f 100644
+index 6c23903..4358919 100644
 --- a/mediapipe/modules/face_geometry/effect_renderer_calculator.proto
 +++ b/mediapipe/modules/face_geometry/effect_renderer_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator_options.proto";
  
 diff --git a/mediapipe/modules/face_geometry/env_generator_calculator.proto b/mediapipe/modules/face_geometry/env_generator_calculator.proto
-index dea2ae0..fa70233 100644
+index dea2ae0..5c80760 100644
 --- a/mediapipe/modules/face_geometry/env_generator_calculator.proto
 +++ b/mediapipe/modules/face_geometry/env_generator_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator_options.proto";
  import "mediapipe/modules/face_geometry/protos/environment.proto";
 diff --git a/mediapipe/modules/face_geometry/geometry_pipeline_calculator.proto b/mediapipe/modules/face_geometry/geometry_pipeline_calculator.proto
-index 638bb45..b589653 100644
+index 638bb45..06e61cf 100644
 --- a/mediapipe/modules/face_geometry/geometry_pipeline_calculator.proto
 +++ b/mediapipe/modules/face_geometry/geometry_pipeline_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator_options.proto";
  
 diff --git a/mediapipe/modules/face_geometry/protos/environment.proto b/mediapipe/modules/face_geometry/protos/environment.proto
-index cca3f29..e7a6970 100644
+index cca3f29..184178a 100644
 --- a/mediapipe/modules/face_geometry/protos/environment.proto
 +++ b/mediapipe/modules/face_geometry/protos/environment.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.face_geometry;
-+package akihabara.framework.protobuf.face_geometry;
+ package mediapipe.face_geometry;
++option csharp_namespace = "Akihabara.Framework.Protobuf.FaceGeometry";
  
  option java_package = "com.google.mediapipe.modules.facegeometry";
  option java_outer_classname = "EnvironmentProto";
 diff --git a/mediapipe/modules/face_geometry/protos/face_geometry.proto b/mediapipe/modules/face_geometry/protos/face_geometry.proto
-index b91a7d7..5c78694 100644
+index b91a7d7..5baac68 100644
 --- a/mediapipe/modules/face_geometry/protos/face_geometry.proto
 +++ b/mediapipe/modules/face_geometry/protos/face_geometry.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.face_geometry;
-+package akihabara.framework.protobuf.face_geometry;
+ package mediapipe.face_geometry;
++option csharp_namespace = "Akihabara.Framework.Protobuf.FaceGeometry";
  
  import "mediapipe/framework/formats/matrix_data.proto";
  import "mediapipe/modules/face_geometry/protos/mesh_3d.proto";
 diff --git a/mediapipe/modules/face_geometry/protos/geometry_pipeline_metadata.proto b/mediapipe/modules/face_geometry/protos/geometry_pipeline_metadata.proto
-index dac0e25..c6eaa23 100644
+index dac0e25..19f9cf1 100644
 --- a/mediapipe/modules/face_geometry/protos/geometry_pipeline_metadata.proto
 +++ b/mediapipe/modules/face_geometry/protos/geometry_pipeline_metadata.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.face_geometry;
-+package akihabara.framework.protobuf.face_geometry;
+ package mediapipe.face_geometry;
++option csharp_namespace = "Akihabara.Framework.Protobuf.FaceGeometry";
  
  import "mediapipe/modules/face_geometry/protos/mesh_3d.proto";
  
 diff --git a/mediapipe/modules/face_geometry/protos/mesh_3d.proto b/mediapipe/modules/face_geometry/protos/mesh_3d.proto
-index 4db45c1..55ec336 100644
+index 4db45c1..b9c3802 100644
 --- a/mediapipe/modules/face_geometry/protos/mesh_3d.proto
 +++ b/mediapipe/modules/face_geometry/protos/mesh_3d.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe.face_geometry;
-+package akihabara.framework.protobuf.face_geometry;
+ package mediapipe.face_geometry;
++option csharp_namespace = "Akihabara.Framework.Protobuf.FaceGeometry";
  
  option java_package = "com.google.mediapipe.modules.facegeometry";
  option java_outer_classname = "Mesh3dProto";
 diff --git a/mediapipe/modules/holistic_landmark/calculators/roi_tracking_calculator.proto b/mediapipe/modules/holistic_landmark/calculators/roi_tracking_calculator.proto
-index ec3cf22..86468f0 100644
+index ec3cf22..b1d8ab4 100644
 --- a/mediapipe/modules/holistic_landmark/calculators/roi_tracking_calculator.proto
 +++ b/mediapipe/modules/holistic_landmark/calculators/roi_tracking_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/modules/objectron/calculators/a_r_capture_metadata.proto b/mediapipe/modules/objectron/calculators/a_r_capture_metadata.proto
-index edc8c4b..17cf580 100644
+index edc8c4b..e4c14fb 100644
 --- a/mediapipe/modules/objectron/calculators/a_r_capture_metadata.proto
 +++ b/mediapipe/modules/objectron/calculators/a_r_capture_metadata.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Info about the camera characteristics used to capture images and depth data.
  // See developer.apple.com/documentation/avfoundation/avcameracalibrationdata
 diff --git a/mediapipe/modules/objectron/calculators/annotation_data.proto b/mediapipe/modules/objectron/calculators/annotation_data.proto
-index 897e700..90d701b 100644
+index 897e700..d490915 100644
 --- a/mediapipe/modules/objectron/calculators/annotation_data.proto
 +++ b/mediapipe/modules/objectron/calculators/annotation_data.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto3";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/modules/objectron/calculators/a_r_capture_metadata.proto";
  import "mediapipe/modules/objectron/calculators/object.proto";
 diff --git a/mediapipe/modules/objectron/calculators/belief_decoder_config.proto b/mediapipe/modules/objectron/calculators/belief_decoder_config.proto
-index f0f10ae..cd891e8 100644
+index f0f10ae..f4e5eac 100644
 --- a/mediapipe/modules/objectron/calculators/belief_decoder_config.proto
 +++ b/mediapipe/modules/objectron/calculators/belief_decoder_config.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message BeliefDecoderConfig {
    optional float heatmap_threshold = 1 [default = 0.9];
 diff --git a/mediapipe/modules/objectron/calculators/camera_parameters.proto b/mediapipe/modules/objectron/calculators/camera_parameters.proto
-index f5c843b..1df1466 100644
+index f5c843b..e11e9b6 100644
 --- a/mediapipe/modules/objectron/calculators/camera_parameters.proto
 +++ b/mediapipe/modules/objectron/calculators/camera_parameters.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message CameraParametersProto {
    // This number is non-negative, it represents camera height above ground
 diff --git a/mediapipe/modules/objectron/calculators/filter_detection_calculator.proto b/mediapipe/modules/objectron/calculators/filter_detection_calculator.proto
-index ea79b8d..dfeac0a 100644
+index ea79b8d..3a7a2e2 100644
 --- a/mediapipe/modules/objectron/calculators/filter_detection_calculator.proto
 +++ b/mediapipe/modules/objectron/calculators/filter_detection_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/modules/objectron/calculators/frame_annotation_to_rect_calculator.proto b/mediapipe/modules/objectron/calculators/frame_annotation_to_rect_calculator.proto
-index 8959cb8..6b06a08 100644
+index 8959cb8..0e75776 100644
 --- a/mediapipe/modules/objectron/calculators/frame_annotation_to_rect_calculator.proto
 +++ b/mediapipe/modules/objectron/calculators/frame_annotation_to_rect_calculator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/modules/objectron/calculators/frame_annotation_tracker_calculator.proto b/mediapipe/modules/objectron/calculators/frame_annotation_tracker_calculator.proto
-index f37308a..38b08ba 100644
+index f37308a..21d2f81 100644
 --- a/mediapipe/modules/objectron/calculators/frame_annotation_tracker_calculator.proto
 +++ b/mediapipe/modules/objectron/calculators/frame_annotation_tracker_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/modules/objectron/calculators/lift_2d_frame_annotation_to_3d_calculator.proto b/mediapipe/modules/objectron/calculators/lift_2d_frame_annotation_to_3d_calculator.proto
-index a3005c1..55c08eb 100644
+index a3005c1..f6e6613 100644
 --- a/mediapipe/modules/objectron/calculators/lift_2d_frame_annotation_to_3d_calculator.proto
 +++ b/mediapipe/modules/objectron/calculators/lift_2d_frame_annotation_to_3d_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/modules/objectron/calculators/belief_decoder_config.proto";
 diff --git a/mediapipe/modules/objectron/calculators/object.proto b/mediapipe/modules/objectron/calculators/object.proto
-index a07e83f..3cf0f8f 100644
+index a07e83f..3eb3124 100644
 --- a/mediapipe/modules/objectron/calculators/object.proto
 +++ b/mediapipe/modules/objectron/calculators/object.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto3";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message KeyPoint {
    // The position of the keypoint in the local coordinate system of the rigid
 diff --git a/mediapipe/modules/objectron/calculators/tensors_to_objects_calculator.proto b/mediapipe/modules/objectron/calculators/tensors_to_objects_calculator.proto
-index 8d46fce..ec609e4 100644
+index 8d46fce..fc55c6d 100644
 --- a/mediapipe/modules/objectron/calculators/tensors_to_objects_calculator.proto
 +++ b/mediapipe/modules/objectron/calculators/tensors_to_objects_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/modules/objectron/calculators/belief_decoder_config.proto";
 diff --git a/mediapipe/modules/objectron/calculators/tflite_tensors_to_objects_calculator.proto b/mediapipe/modules/objectron/calculators/tflite_tensors_to_objects_calculator.proto
-index 32520d9..d96f2dc 100644
+index 32520d9..54dfa5b 100644
 --- a/mediapipe/modules/objectron/calculators/tflite_tensors_to_objects_calculator.proto
 +++ b/mediapipe/modules/objectron/calculators/tflite_tensors_to_objects_calculator.proto
-@@ -16,7 +16,7 @@
- 
+@@ -17,6 +17,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  import "mediapipe/modules/objectron/calculators/belief_decoder_config.proto";
 diff --git a/mediapipe/util/audio_decoder.proto b/mediapipe/util/audio_decoder.proto
-index 67c54a2..a51e620 100644
+index 67c54a2..0347ce7 100644
 --- a/mediapipe/util/audio_decoder.proto
 +++ b/mediapipe/util/audio_decoder.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/util/color.proto b/mediapipe/util/color.proto
-index c612112..bfaf542 100644
+index c612112..4ba764b 100644
 --- a/mediapipe/util/color.proto
 +++ b/mediapipe/util/color.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message Color {
    optional int32 r = 1;
 diff --git a/mediapipe/util/render_data.proto b/mediapipe/util/render_data.proto
-index 54a2d65..6bcab07 100644
+index 54a2d65..1ce3267 100644
 --- a/mediapipe/util/render_data.proto
 +++ b/mediapipe/util/render_data.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/color.proto";
  
 diff --git a/mediapipe/util/tracking/box_detector.proto b/mediapipe/util/tracking/box_detector.proto
-index 287ba4e..0b1c524 100644
+index 287ba4e..608aeef 100644
 --- a/mediapipe/util/tracking/box_detector.proto
 +++ b/mediapipe/util/tracking/box_detector.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/box_tracker.proto";
  import "mediapipe/util/tracking/region_flow.proto";
 diff --git a/mediapipe/util/tracking/box_tracker.proto b/mediapipe/util/tracking/box_tracker.proto
-index 404c1bd..ba9d1b1 100644
+index 404c1bd..7156238 100644
 --- a/mediapipe/util/tracking/box_tracker.proto
 +++ b/mediapipe/util/tracking/box_tracker.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/tracking.proto";
  
 diff --git a/mediapipe/util/tracking/camera_motion.proto b/mediapipe/util/tracking/camera_motion.proto
-index 9e19f4a..9500c68 100644
+index 9e19f4a..e93b830 100644
 --- a/mediapipe/util/tracking/camera_motion.proto
 +++ b/mediapipe/util/tracking/camera_motion.proto
-@@ -21,7 +21,7 @@
- 
+@@ -22,6 +22,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/motion_models.proto";
  
 diff --git a/mediapipe/util/tracking/flow_packager.proto b/mediapipe/util/tracking/flow_packager.proto
-index 5ab71e7..dbbdd1a 100644
+index 5ab71e7..ae91f4c 100644
 --- a/mediapipe/util/tracking/flow_packager.proto
 +++ b/mediapipe/util/tracking/flow_packager.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/motion_models.proto";
  import "mediapipe/util/tracking/region_flow.proto";
 diff --git a/mediapipe/util/tracking/frame_selection.proto b/mediapipe/util/tracking/frame_selection.proto
-index 35712c2..d3664b3 100644
+index 35712c2..2d8c2a6 100644
 --- a/mediapipe/util/tracking/frame_selection.proto
 +++ b/mediapipe/util/tracking/frame_selection.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/camera_motion.proto";
  import "mediapipe/util/tracking/frame_selection_solution_evaluator.proto";
 diff --git a/mediapipe/util/tracking/frame_selection_solution_evaluator.proto b/mediapipe/util/tracking/frame_selection_solution_evaluator.proto
-index b2b92c9..b82b90f 100644
+index b2b92c9..4610c79 100644
 --- a/mediapipe/util/tracking/frame_selection_solution_evaluator.proto
 +++ b/mediapipe/util/tracking/frame_selection_solution_evaluator.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message FrameSelectionSolutionEvaluatorOptions {
    extensions 20000 to max;
 diff --git a/mediapipe/util/tracking/motion_analysis.proto b/mediapipe/util/tracking/motion_analysis.proto
-index 97d6d1d..46cf234 100644
+index 97d6d1d..993ee37 100644
 --- a/mediapipe/util/tracking/motion_analysis.proto
 +++ b/mediapipe/util/tracking/motion_analysis.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/motion_estimation.proto";
  import "mediapipe/util/tracking/motion_saliency.proto";
 diff --git a/mediapipe/util/tracking/motion_estimation.proto b/mediapipe/util/tracking/motion_estimation.proto
-index 79d60c6..4394aa2 100644
+index 79d60c6..ffe3e26 100644
 --- a/mediapipe/util/tracking/motion_estimation.proto
 +++ b/mediapipe/util/tracking/motion_estimation.proto
-@@ -15,7 +15,7 @@
- // Settings for MotionEstimation.
+@@ -16,6 +16,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Note: In general for Estimation modes, the prefix are used as follows:
  // L2:        minimize squared norm of error
 diff --git a/mediapipe/util/tracking/motion_models.proto b/mediapipe/util/tracking/motion_models.proto
-index 889cc42..f43d042 100644
+index 889cc42..84ce542 100644
 --- a/mediapipe/util/tracking/motion_models.proto
 +++ b/mediapipe/util/tracking/motion_models.proto
-@@ -23,7 +23,7 @@
- 
+@@ -24,6 +24,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Here x represents a 2D point in the image plane, in the following
  // coordinate system:
 diff --git a/mediapipe/util/tracking/motion_saliency.proto b/mediapipe/util/tracking/motion_saliency.proto
-index b7702da..d22312d 100644
+index b7702da..b11684a 100644
 --- a/mediapipe/util/tracking/motion_saliency.proto
 +++ b/mediapipe/util/tracking/motion_saliency.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Next tag: 17
  message MotionSaliencyOptions {
 diff --git a/mediapipe/util/tracking/push_pull_filtering.proto b/mediapipe/util/tracking/push_pull_filtering.proto
-index fa27e87..19b4d4d 100644
+index fa27e87..78d15e8 100644
 --- a/mediapipe/util/tracking/push_pull_filtering.proto
 +++ b/mediapipe/util/tracking/push_pull_filtering.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message PushPullOptions {
    // Sigma for color difference.
 diff --git a/mediapipe/util/tracking/region_flow.proto b/mediapipe/util/tracking/region_flow.proto
-index bd93c0b..016f0f0 100644
+index bd93c0b..eb556d4 100644
 --- a/mediapipe/util/tracking/region_flow.proto
 +++ b/mediapipe/util/tracking/region_flow.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  option java_package = "com.google.mediapipe.tracking";
  option java_multiple_files = true;
 diff --git a/mediapipe/util/tracking/region_flow_computation.proto b/mediapipe/util/tracking/region_flow_computation.proto
-index 800e430..acf3523 100644
+index 800e430..1ed1a48 100644
 --- a/mediapipe/util/tracking/region_flow_computation.proto
 +++ b/mediapipe/util/tracking/region_flow_computation.proto
-@@ -18,7 +18,7 @@
- 
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/tone_estimation.proto";
  
 diff --git a/mediapipe/util/tracking/tone_estimation.proto b/mediapipe/util/tracking/tone_estimation.proto
-index 711765a..fa4fc02 100644
+index 711765a..2153768 100644
 --- a/mediapipe/util/tracking/tone_estimation.proto
 +++ b/mediapipe/util/tracking/tone_estimation.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/tone_models.proto";
  
 diff --git a/mediapipe/util/tracking/tone_models.proto b/mediapipe/util/tracking/tone_models.proto
-index d53ad21..560ec00 100644
+index d53ad21..846b564 100644
 --- a/mediapipe/util/tracking/tone_models.proto
 +++ b/mediapipe/util/tracking/tone_models.proto
-@@ -17,7 +17,7 @@
- 
+@@ -18,6 +18,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  // Transforms a 3D color vector x = (c1, c2, c3) according to
  //  [ gain_c1    0      0      bias_c1       *   [ c1
 diff --git a/mediapipe/util/tracking/tracked_detection_manager_config.proto b/mediapipe/util/tracking/tracked_detection_manager_config.proto
-index 9162c95..67aa1d2 100644
+index 9162c95..62df410 100644
 --- a/mediapipe/util/tracking/tracked_detection_manager_config.proto
 +++ b/mediapipe/util/tracking/tracked_detection_manager_config.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  message TrackedDetectionManagerConfig {
    // When we compare two detection boxes, if the ratio of the area is
 diff --git a/mediapipe/util/tracking/tracking.proto b/mediapipe/util/tracking/tracking.proto
-index ff00380..af1bff5 100644
+index ff00380..153c3bd 100644
 --- a/mediapipe/util/tracking/tracking.proto
 +++ b/mediapipe/util/tracking/tracking.proto
-@@ -14,7 +14,7 @@
- 
+@@ -15,6 +15,7 @@
  syntax = "proto2";
  
--package mediapipe;
-+package akihabara.framework.protobuf;
+ package mediapipe;
++option csharp_namespace = "Akihabara.Framework.Protobuf";
  
  import "mediapipe/util/tracking/motion_models.proto";
  


### PR DESCRIPTION
This pull request fixes the build process, namely issue #21.
It also has the potential to fix CI as `libmediapipe_c.{so,dll}` now fully works, both CPU and GPU.

There are 2 changes:
- `proto_namespace.diff` now adds a `csharp_namespace` property after the `package mediapipe;` lines instead of changing the `package` itself as suggested by Homuler in [this message](https://github.com/vignetteapp/Akihabara/issues/21#issuecomment-922386541),
- `build.py` has been revised to account for our tech stack and directory structure.