### PR TITLE
Code cleanup

### DIFF
--- a/src/Akihabara.Tests/Framework/CalculatorGraphTest.cs
+++ b/src/Akihabara.Tests/Framework/CalculatorGraphTest.cs
@@ -1,12 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
 using Akihabara.Framework;
-using Akihabara.Framework.Port;
 using Akihabara.Framework.Packet;
+using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
+using NUnit.Framework;
 
 namespace Akihabara.Tests.Framework
 {

--- a/src/Akihabara.Tests/Framework/ImageFormat/ImageFrameTest.cs
+++ b/src/Akihabara.Tests/Framework/ImageFormat/ImageFrameTest.cs
@@ -1,16 +1,16 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
-using Akihabara.Core;
-using Akihabara.Framework.ImageFormat;
 using System;
 using System.Linq;
+using Akihabara.Core;
+using Akihabara.Framework.ImageFormat;
+using NUnit.Framework;
 using UnmanageUtility;
 
 namespace Akihabara.Tests.Format
 {
+    [TestFixture]
     public class ImageFrameTest
     {
         #region Constructor

--- a/src/Akihabara.Tests/Framework/Packet/BoolPacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/BoolPacketTest.cs
@@ -1,13 +1,12 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
-using NUnit.Framework;
 using Akihabara.Core;
 using Akihabara.Framework;
-using Akihabara.Framework.Port;
 using Akihabara.Framework.Packet;
+using Akihabara.Framework.Port;
+using NUnit.Framework;
 
 namespace Akihabara.Tests.Framework.Packet
 {

--- a/src/Akihabara.Tests/Framework/Packet/EglSurfaceHolderPacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/EglSurfaceHolderPacketTest.cs
@@ -1,18 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
-
-using Akihabara.Core;
-using Akihabara.Framework;
-using Akihabara.Framework.Packet;
-using Akihabara.Framework.Port;
-using Akihabara.Gpu;
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 namespace Akihabara.Tests.Framework.Packet
 {
@@ -20,7 +7,7 @@ namespace Akihabara.Tests.Framework.Packet
     [TestFixture]
     public class EglSurfaceHolderPacketTest
     {
-        #region Constructor
+    #region Constructor
         [Test]
         public void Ctor_ShouldInstantiatePacket_When_CalledWithNoArguments()
         {
@@ -39,9 +26,9 @@ namespace Akihabara.Tests.Framework.Packet
             Assert.True(packet.ValidateAsType().ok);
             Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
         }
-        #endregion
+    #endregion
 
-        #region #isDisposed
+    #region #isDisposed
         [Test]
         public void IsDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -58,9 +45,9 @@ namespace Akihabara.Tests.Framework.Packet
 
             Assert.True(packet.IsDisposed);
         }
-#endregion
+    #endregion
 
-        #region #Get
+    #region #Get
         [Test, SignalAbort]
         public void Get_ShouldThrowMediaPipeException_When_DataIsEmpty()
         {
@@ -80,9 +67,9 @@ namespace Akihabara.Tests.Framework.Packet
             Assert.False(value.OwnsResource());
             Assert.True(value.FlipY());
         }
-        #endregion
+    #endregion
 
-        #region #DebugTypeName
+    #region #DebugTypeName
         [Test, GpuOnly]
         public void DebugTypeName_ShouldReturnFloat_When_ValueIsSet()
         {
@@ -90,7 +77,7 @@ namespace Akihabara.Tests.Framework.Packet
 
             Assert.AreEqual(packet.DebugTypeName(), "std::unique_ptr<mediapipe::EglSurfaceHolder, std::default_delete<mediapipe::EglSurfaceHolder> >");
         }
-        #endregion
+    #endregion
     }
 #endif
 }

--- a/src/Akihabara.Tests/Framework/Packet/FloatArrayPacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/FloatArrayPacketTest.cs
@@ -1,17 +1,12 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
+using System;
 using Akihabara.Core;
 using Akihabara.Framework;
 using Akihabara.Framework.Packet;
 using Akihabara.Framework.Port;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Tests.Framework.Packet
 {

--- a/src/Akihabara.Tests/Framework/Packet/FloatPacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/FloatPacketTest.cs
@@ -1,17 +1,12 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
+using System;
 using Akihabara.Core;
 using Akihabara.Framework;
 using Akihabara.Framework.Packet;
 using Akihabara.Framework.Port;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Tests.Framework.Packet
 {

--- a/src/Akihabara.Tests/Framework/Packet/ImageFramePacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/ImageFramePacketTest.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Core;
 using Akihabara.Framework;
@@ -8,11 +7,6 @@ using Akihabara.Framework.ImageFormat;
 using Akihabara.Framework.Packet;
 using Akihabara.Framework.Port;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Tests.Framework.Packet
 {

--- a/src/Akihabara.Tests/Framework/Packet/PacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/PacketTest.cs
@@ -1,11 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
 using Akihabara.Framework;
-using Akihabara.Framework.Port;
 using Akihabara.Framework.Packet;
+using Akihabara.Framework.Port;
+using NUnit.Framework;
 
 namespace Akihabara.Tests.Framework.Packet
 {

--- a/src/Akihabara.Tests/Framework/Packet/SidePacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/SidePacketTest.cs
@@ -1,9 +1,8 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
 using Akihabara.Framework.Packet;
+using NUnit.Framework;
 
 namespace Akihabara.Tests.Framework.Packet
 {

--- a/src/Akihabara.Tests/Framework/Packet/StringPacketTest.cs
+++ b/src/Akihabara.Tests/Framework/Packet/StringPacketTest.cs
@@ -1,14 +1,13 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
+using System;
+using System.Text.RegularExpressions;
 using Akihabara.Core;
 using Akihabara.Framework;
 using Akihabara.Framework.Packet;
 using Akihabara.Framework.Port;
 using NUnit.Framework;
-using System;
-using System.Text.RegularExpressions;
 
 namespace Akihabara.Tests.Framework.Packet
 {

--- a/src/Akihabara.Tests/Framework/Port/StatusOrGpuResources.cs
+++ b/src/Akihabara.Tests/Framework/Port/StatusOrGpuResources.cs
@@ -1,12 +1,12 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Gpu;
 using NUnit.Framework;
 
 namespace Akihabara.Framework.Port
 {
+    [TestFixture]
     public class StatusOrGpuResourcesTest
     {
         #region #status

--- a/src/Akihabara.Tests/Framework/Port/StatusOrImageFrameTest.cs
+++ b/src/Akihabara.Tests/Framework/Port/StatusOrImageFrameTest.cs
@@ -1,15 +1,15 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Framework;
+using Akihabara.Framework.ImageFormat;
 using Akihabara.Framework.Packet;
 using Akihabara.Framework.Port;
-using Akihabara.Framework.ImageFormat;
 using NUnit.Framework;
 
 namespace Tests
 {
+    [TestFixture]
     public class StatusOrImageFrameTest
     {
         #region #status
@@ -56,7 +56,7 @@ namespace Tests
         }
         #endregion
 
-        private StatusOrImageFrame InitializeSubject()
+        private static StatusOrImageFrame InitializeSubject()
         {
             var imageFrame = new ImageFrame(ImageFormat.Format.Sbgra, 10, 10);
             var packet = new ImageFramePacket(imageFrame, new Timestamp(1));

--- a/src/Akihabara.Tests/Framework/Port/StatusTest.cs
+++ b/src/Akihabara.Tests/Framework/Port/StatusTest.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Core;
 using Akihabara.Framework.Port;
@@ -8,6 +7,7 @@ using NUnit.Framework;
 
 namespace Tests
 {
+    [TestFixture]
     public class StatusTest
     {
         #region #code

--- a/src/Akihabara.Tests/Framework/TimestampTest.cs
+++ b/src/Akihabara.Tests/Framework/TimestampTest.cs
@@ -1,9 +1,8 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
 using Akihabara.Framework;
+using NUnit.Framework;
 
 namespace Akihabara.Tests.Framework
 {

--- a/src/Akihabara.Tests/Gpu/EglSurfaceHolderTest.cs
+++ b/src/Akihabara.Tests/Gpu/EglSurfaceHolderTest.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 #if OPENGL_ES
 using Akihabara.Gpu;
@@ -10,9 +9,10 @@ using System;
 
 namespace Akihabara.Tests.Gpu
 {
+    [TestFixture]
     public class EglSurfaceHolderTest
     {
-        #region Constructor
+#region Constructor
         [Test, GpuOnly]
         public void Ctor_ShouldInstantiateEglSurfaceHolder()
         {
@@ -20,9 +20,9 @@ namespace Akihabara.Tests.Gpu
 
             Assert.False(eglSurfaceHolder.FlipY());
         }
-        #endregion
+#endregion
 
-        #region #isDisposed
+#region #isDisposed
         [Test, GpuOnly]
         public void isDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
@@ -39,9 +39,9 @@ namespace Akihabara.Tests.Gpu
 
             Assert.True(eglSurfaceHolder.isDisposed);
         }
-        #endregion
+#endregion
 
-        #region #SetFlipY
+#region #SetFlipY
         [Test, GpuOnly]
         public void SetFilpY_ShouldSetFlipY()
         {
@@ -50,9 +50,9 @@ namespace Akihabara.Tests.Gpu
 
             Assert.True(eglSurfaceHolder.FlipY());
         }
-        #endregion
+#endregion
 
-        #region #SetSurface
+#region #SetSurface
         void ExpectSetSurfaceOk(IntPtr surface)
         {
             var eglSurfaceHolder = new EglSurfaceHolder();
@@ -86,7 +86,7 @@ namespace Akihabara.Tests.Gpu
             ExpectSetSurfaceOk(texture.GetNativeTexturePtr());
         }
         */
-        #endregion
+#endregion
     }
 }
 #endif

--- a/src/Akihabara.Tests/Gpu/GlCalculatorHelperTest.cs
+++ b/src/Akihabara.Tests/Gpu/GlCalculatorHelperTest.cs
@@ -1,15 +1,15 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.Gpu;
-using Akihabara.Framework.Port;
-using Akihabara.Framework.ImageFormat;
-using NUnit.Framework;
 using System;
+using Akihabara.Framework.ImageFormat;
+using Akihabara.Framework.Port;
+using Akihabara.Gpu;
+using NUnit.Framework;
 
 namespace Akihabara.Tests.Gpu
 {
+    [TestFixture]
     public class GlCalculatorHelperTest
     {
         #region Constructor
@@ -94,8 +94,7 @@ namespace Akihabara.Tests.Gpu
             glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
             var imageFrame = new ImageFrame(ImageFormat.Format.Srgba, 32, 24);
-            var status = glCalculatorHelper.RunInGlContext(() =>
-            {
+            var status = glCalculatorHelper.RunInGlContext(() => {
                 var texture = glCalculatorHelper.CreateSourceTexture(imageFrame);
 
                 Assert.AreEqual(texture.Width, 32);
@@ -116,8 +115,7 @@ namespace Akihabara.Tests.Gpu
             glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
             var imageFrame = new ImageFrame(ImageFormat.Format.Sbgra, 32, 24);
-            var status = glCalculatorHelper.RunInGlContext(() =>
-            {
+            var status = glCalculatorHelper.RunInGlContext(() => {
                 using (var texture = glCalculatorHelper.CreateSourceTexture(imageFrame))
                 {
                     texture.Release();
@@ -136,8 +134,7 @@ namespace Akihabara.Tests.Gpu
             var glCalculatorHelper = new GlCalculatorHelper();
             glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
-            var status = glCalculatorHelper.RunInGlContext(() =>
-            {
+            var status = glCalculatorHelper.RunInGlContext(() => {
                 var glTexture = glCalculatorHelper.CreateDestinationTexture(32, 24, GpuBufferFormat.KBgra32);
 
                 Assert.AreEqual(glTexture.Width, 32);
@@ -170,13 +167,13 @@ namespace Akihabara.Tests.Gpu
 
             var glContext = glCalculatorHelper.GetGlContext();
 
-            #if OPENGL_ES
+#if OPENGL_ES
             Assert.AreNotEqual(glContext.eglContext, IntPtr.Zero);
-            #elif UNITY_STANDALONE_OSX
+#elif UNITY_STANDALONE_OSX
             Assert.AreNotEqual(glContext.nsglContext, IntPtr.Zero);
-            #elif UNITY_IOS
+#elif UNITY_IOS
             Assert.AreNotEqual(glContext.eaglContext, IntPtr.Zero);
-            #endif
+#endif
         }
         #endregion
     }

--- a/src/Akihabara.Tests/Gpu/GlContextTest.cs
+++ b/src/Akihabara.Tests/Gpu/GlContextTest.cs
@@ -1,13 +1,13 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.Gpu;
 using Akihabara.Framework.Port;
+using Akihabara.Gpu;
 using NUnit.Framework;
 
 namespace Akihabara.Tests.Gpu
 {
+    [TestFixture]
     public class GlContextTest
     {
         #region GetCurrent
@@ -25,8 +25,7 @@ namespace Akihabara.Tests.Gpu
             var glCalculatorHelper = new GlCalculatorHelper();
             glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
-            glCalculatorHelper.RunInGlContext(() =>
-            {
+            glCalculatorHelper.RunInGlContext(() => {
                 var glContext = GlContext.GetCurrent();
 
                 Assert.NotNull(glContext);
@@ -51,30 +50,25 @@ namespace Akihabara.Tests.Gpu
         {
             var glContext = GetGlContext();
 
-            #if OPENGL_ES
+#if OPENGL_ES
             Assert.AreNotEqual(glContext.eglDisplay, IntPtr.Zero);
             Assert.AreNotEqual(glContext.eglConfig, IntPtr.Zero);
             Assert.AreNotEqual(glContext.eglContext, IntPtr.Zero);
             Assert.AreEqual(glContext.glMajorVersion, 3);
             Assert.AreEqual(glContext.glMinorVersion, 2);
             Assert.AreEqual(glContext.glFinishCount, 0);
-            #elif STANDALONE_OSX
-            Assert.AreNotEqual(glContext.nsglContext, IntPtr.Zero);
-            #elif IOS
-            Assert.AreNotEqual(glContext.eaglContext, IntPtr.Zero);
-            #endif
+#endif
         }
-        #endregion
+#endregion
 
-        private GlContext GetGlContext()
+        private static GlContext GetGlContext()
         {
             GlContext glContext = null;
 
             var glCalculatorHelper = new GlCalculatorHelper();
             glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
-            glCalculatorHelper.RunInGlContext(() =>
-            {
+            glCalculatorHelper.RunInGlContext(() => {
                 glContext = GlContext.GetCurrent();
                 return Status.Ok();
             }).AssertOk();

--- a/src/Akihabara.Tests/Gpu/GlTextureTest.cs
+++ b/src/Akihabara.Tests/Gpu/GlTextureTest.cs
@@ -1,12 +1,12 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Gpu;
 using NUnit.Framework;
 
 namespace Akihabara.Tests.Gpu
 {
+    [TestFixture]
     public class GlTextureTest
     {
         #region Constructor

--- a/src/Akihabara.Tests/Gpu/GpuResourcesTest.cs
+++ b/src/Akihabara.Tests/Gpu/GpuResourcesTest.cs
@@ -1,12 +1,12 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Gpu;
 using NUnit.Framework;
 
 namespace Tests
 {
+    [TestFixture]
     public class GpuResourcesTest
     {
         #region Create

--- a/src/Akihabara.Tests/GpuOnlyAttribute.cs
+++ b/src/Akihabara.Tests/GpuOnlyAttribute.cs
@@ -1,9 +1,8 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
 using System;
+using NUnit.Framework;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public class GpuOnlyAttribute : CategoryAttribute

--- a/src/Akihabara.Tests/Graph/HelloWorldGraphTest.cs
+++ b/src/Akihabara.Tests/Graph/HelloWorldGraphTest.cs
@@ -1,12 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
-using System;
 using Akihabara.Framework;
-using Akihabara.Framework.Port;
 using Akihabara.Framework.Packet;
+using Akihabara.Framework.Port;
+using NUnit.Framework;
 
 namespace Akihabara.Tests.Graph
 {
@@ -38,8 +36,7 @@ node {
         [Test]
         public static void MainTest()
         {
-            Assert.DoesNotThrow(() =>
-            {
+            Assert.DoesNotThrow(() => {
                 helloWorldGraph = new CalculatorGraph(graphConfigText);
                 outputStreamPoller = helloWorldGraph.AddOutputStreamPoller<string>(outputStream).Value();
             });
@@ -47,9 +44,8 @@ node {
             Status graphStartResult = helloWorldGraph.StartRun();
             Assert.True(graphStartResult.ok);
 
-            Assert.DoesNotThrow(() =>
-            {
-                int timestamp = System.Environment.TickCount & System.Int32.MaxValue;
+            Assert.DoesNotThrow(() => {
+                int timestamp = System.Environment.TickCount & int.MaxValue;
                 var inputPacket = new StringPacket("Hello World", new Timestamp(timestamp));
                 outputPacket = new StringPacket();
                 pushedInput = helloWorldGraph.AddPacketToInputStream(inputStream, inputPacket);

--- a/src/Akihabara.Tests/SignalAbortAttribute.cs
+++ b/src/Akihabara.Tests/SignalAbortAttribute.cs
@@ -1,9 +1,8 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using NUnit.Framework;
 using System;
+using NUnit.Framework;
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple=false)]
-public class SignalAbortAttribute : CategoryAttribute {}
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public class SignalAbortAttribute : CategoryAttribute { }

--- a/src/Akihabara/Core/DisposableObject.cs
+++ b/src/Akihabara/Core/DisposableObject.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Threading;
@@ -23,7 +22,7 @@ namespace Akihabara.Core
         protected DisposableObject(bool isOwner)
         {
             IsDisposed = false;
-            this.IsOwner = isOwner;
+            IsOwner = isOwner;
         }
 
         public void Dispose()

--- a/src/Akihabara/Core/IMpResourceHandle.cs
+++ b/src/Akihabara/Core/IMpResourceHandle.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 

--- a/src/Akihabara/Core/MediapipeException.cs
+++ b/src/Akihabara/Core/MediapipeException.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 

--- a/src/Akihabara/Core/MediapipePluginException.cs
+++ b/src/Akihabara/Core/MediapipePluginException.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 

--- a/src/Akihabara/Core/MpResourceHandle.cs
+++ b/src/Akihabara/Core/MpResourceHandle.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -18,15 +17,13 @@ namespace Akihabara.Core
 
         protected MpResourceHandle(IntPtr ptr, bool isOwner = true) : base(isOwner)
         {
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         #region IMpResourceHandle
 
-        public IntPtr MpPtr
-        {
-            get
-            {
+        public IntPtr MpPtr {
+            get {
                 ThrowIfDisposed();
                 return Ptr;
             }

--- a/src/Akihabara/Core/SharedPtrHandle.cs
+++ b/src/Akihabara/Core/SharedPtrHandle.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 

--- a/src/Akihabara/Core/UniquePtrHandle.cs
+++ b/src/Akihabara/Core/UniquePtrHandle.cs
@@ -1,12 +1,7 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Core
 {

--- a/src/Akihabara/External/Glog.cs
+++ b/src/Akihabara/External/Glog.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Native;
 
@@ -26,31 +25,31 @@ namespace Akihabara.External
             switch (severity)
             {
                 case Severity.Info:
-                {
-                    UnsafeNativeMethods.glog_LOG_INFO__PKc(str).Assert();
-                    break;
-                }
+                    {
+                        UnsafeNativeMethods.glog_LOG_INFO__PKc(str).Assert();
+                        break;
+                    }
                 case Severity.Warning:
-                {
-                    UnsafeNativeMethods.glog_LOG_WARNING__PKc(str).Assert();
-                    break;
-                }
+                    {
+                        UnsafeNativeMethods.glog_LOG_WARNING__PKc(str).Assert();
+                        break;
+                    }
                 case Severity.Error:
-                {
-                    UnsafeNativeMethods.glog_LOG_ERROR__PKc(str).Assert();
-                    break;
-                }
+                    {
+                        UnsafeNativeMethods.glog_LOG_ERROR__PKc(str).Assert();
+                        break;
+                    }
                 case Severity.Fatal:
-                {
-                    UnsafeNativeMethods.glog_LOG_FATAL__PKc(str).Assert();
-                    break;
-                }
+                    {
+                        UnsafeNativeMethods.glog_LOG_FATAL__PKc(str).Assert();
+                        break;
+                    }
                 default:
-                {
-                    // just to appease Roslyn and ReSharper
-                    UnsafeNativeMethods.glog_LOG_INFO__PKc(str);
-                    break;
-                }
+                    {
+                        // just to appease Roslyn and ReSharper
+                        UnsafeNativeMethods.glog_LOG_INFO__PKc(str);
+                        break;
+                    }
             }
         }
     }

--- a/src/Akihabara/External/Protobuf.cs
+++ b/src/Akihabara/External/Protobuf.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Collections.Generic;

--- a/src/Akihabara/External/SerializedProto.cs
+++ b/src/Akihabara/External/SerializedProto.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/External/SerializedProtoVector.cs
+++ b/src/Akihabara/External/SerializedProtoVector.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/External/StdString.cs
+++ b/src/Akihabara/External/StdString.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -17,7 +16,7 @@ namespace Akihabara.External
         public StdString(byte[] bytes) : base()
         {
             UnsafeNativeMethods.std_string__PKc_i(bytes, bytes.Length, out var ptr).Assert();
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         protected override void DeleteMpPtr()

--- a/src/Akihabara/Framework/CalculatorGraph.cs
+++ b/src/Akihabara/Framework/CalculatorGraph.cs
@@ -1,19 +1,17 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
-
-using Google.Protobuf;
 using Akihabara.Core;
-using Akihabara.Framework.Port;
 using Akihabara.Framework.Packet;
+using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Gpu;
 using Akihabara.Native;
-using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
+using Google.Protobuf;
 using SafeNativeMethods = Akihabara.Native.Framework.SafeNativeMethods;
+using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
 
 namespace Akihabara.Framework
 {
@@ -25,19 +23,19 @@ namespace Akihabara.Framework
         public CalculatorGraph() : base()
         {
             UnsafeNativeMethods.mp_CalculatorGraph__(out var ptr).Assert();
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public CalculatorGraph(string textFormatConfig) : base()
         {
             UnsafeNativeMethods.mp_CalculatorGraph__PKc(textFormatConfig, out var ptr).Assert();
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public CalculatorGraph(byte[] serializedConfig) : base()
         {
             UnsafeNativeMethods.mp_CalculatorGraph__PKc_i(serializedConfig, serializedConfig.Length, out var ptr).Assert();
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public CalculatorGraph(CalculatorGraphConfig config) : this(config.ToByteArray()) { }
@@ -84,8 +82,7 @@ namespace Akihabara.Framework
 
         public Status ObserveOutputStream<T, TU>(string streamName, PacketCallback<T, TU> packetCallback, out GCHandle callbackHandle) where T : Packet<TU>
         {
-            NativePacketCallback nativePacketCallback = (IntPtr packetPtr) =>
-            {
+            NativePacketCallback nativePacketCallback = (IntPtr packetPtr) => {
                 Status status = null;
                 try
                 {

--- a/src/Akihabara/Framework/CalculatorGraphConfigExtension.cs
+++ b/src/Akihabara/Framework/CalculatorGraphConfigExtension.cs
@@ -1,10 +1,9 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Google.Protobuf;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
+using Google.Protobuf;
 using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
 
 namespace Akihabara.Framework

--- a/src/Akihabara/Framework/ImageFormat/ImageFormat.cs
+++ b/src/Akihabara/Framework/ImageFormat/ImageFormat.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 namespace Akihabara.Framework.ImageFormat
 {
@@ -21,6 +20,6 @@ namespace Akihabara.Framework.ImageFormat
             Lab8 = 10,
             Sbgra = 11,
             Vec32F2 = 12,
-        }        
+        }
     }
 }

--- a/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
+++ b/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -23,7 +22,7 @@ namespace Akihabara.Framework.ImageFormat
         public ImageFrame() : base()
         {
             UnsafeNativeMethods.mp_ImageFrame__(out var ptr);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public ImageFrame(IntPtr imageFramePtr, bool isOwner = true) : base(imageFramePtr, isOwner) { }
@@ -33,7 +32,7 @@ namespace Akihabara.Framework.ImageFormat
         public ImageFrame(ImageFormat.Format format, int width, int height, uint alignmentBoundary) : base()
         {
             UnsafeNativeMethods.mp_ImageFrame__ui_i_i_ui(format, width, height, alignmentBoundary, out var ptr);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         // there is no equivalent of NativeArray<T> so the closest thing we have is UnmanagedArray<T> or ArrayPooL<T>, which is recommended
@@ -45,12 +44,12 @@ namespace Akihabara.Framework.ImageFormat
             {
                 UnsafeNativeMethods.mp_ImageFrame__ui_i_i_i_Pui8_PF(
                     format, width, height, widthStep,
-                    (IntPtr)pixelData.Ptr,
+                    pixelData.Ptr,
                     ReleasePixelData,
                     out var ptr
                 );
 
-                this.Ptr = ptr;
+                Ptr = ptr;
             }
         }
 

--- a/src/Akihabara/Framework/OutputStreamPoller.cs
+++ b/src/Akihabara/Framework/OutputStreamPoller.cs
@@ -1,12 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
-
 using Akihabara.Core;
-using Akihabara.Native;
 using Akihabara.Framework.Packet;
+using Akihabara.Native;
 using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
 
 namespace Akihabara.Framework

--- a/src/Akihabara/Framework/Packet/BoolPacket.cs
+++ b/src/Akihabara/Framework/Packet/BoolPacket.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Framework.Port;
@@ -19,14 +18,14 @@ namespace Akihabara.Framework.Packet
         {
             UnsafeNativeMethods.mp__MakeBoolPacket__b(value, out var ptr).Assert();
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public BoolPacket(bool value, Timestamp timestamp) : base()
         {
             UnsafeNativeMethods.mp__MakeBoolPacket_At__b_Rt(value, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public override bool Get()

--- a/src/Akihabara/Framework/Packet/ClassificationListPacket.cs
+++ b/src/Akihabara/Framework/Packet/ClassificationListPacket.cs
@@ -1,10 +1,9 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
-using Akihabara.Framework.Protobuf;
 using Akihabara.Framework.Port;
+using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
 
 namespace Akihabara.Framework.Packet

--- a/src/Akihabara/Framework/Packet/ClassificationListVectorPacket.cs
+++ b/src/Akihabara/Framework/Packet/ClassificationListVectorPacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
+using System.Collections.Generic;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/DetectionPacket.cs
+++ b/src/Akihabara/Framework/Packet/DetectionPacket.cs
@@ -1,16 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/DetectionVectorPacket.cs
+++ b/src/Akihabara/Framework/Packet/DetectionVectorPacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
+using System.Collections.Generic;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/EglSurfaceHolderPacket.cs
+++ b/src/Akihabara/Framework/Packet/EglSurfaceHolderPacket.cs
@@ -1,16 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
-
-using Akihabara.Native;
-using ng = Akihabara.Native.Gpu;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Akihabara.Framework.Port;
-using Akihabara.Gpu;
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/FaceGeometryPacket.cs
+++ b/src/Akihabara/Framework/Packet/FaceGeometryPacket.cs
@@ -1,11 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
+using System;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf.FaceGeometry;
 using Akihabara.Native;
-using System;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/FaceGeometryVectorPacket.cs
+++ b/src/Akihabara/Framework/Packet/FaceGeometryVectorPacket.cs
@@ -1,12 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
+using System;
+using System.Collections.Generic;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf.FaceGeometry;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/FloatArrayPacket.cs
+++ b/src/Akihabara/Framework/Packet/FloatArrayPacket.cs
@@ -1,15 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.Framework.Port;
-using nf = Akihabara.Native.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Akihabara.Framework.Port;
 using Akihabara.Native;
+using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
 
 namespace Akihabara.Framework.Packet
 {
@@ -17,11 +12,9 @@ namespace Akihabara.Framework.Packet
     {
         int _Length = -1;
 
-        public int Length
-        {
+        public int Length {
             get { return _Length; }
-            set
-            {
+            set {
                 if (_Length >= 0)
                 {
                     throw new InvalidOperationException("Length is already set and cannot be changed");
@@ -37,16 +30,16 @@ namespace Akihabara.Framework.Packet
 
         public FloatArrayPacket(float[] value) : base()
         {
-            nf.UnsafeNativeMethods.mp__MakeFloatArrayPacket__Pf_i(value, value.Length, out var ptr).Assert();
-            this.Ptr = ptr;
+            UnsafeNativeMethods.mp__MakeFloatArrayPacket__Pf_i(value, value.Length, out var ptr).Assert();
+            Ptr = ptr;
             Length = value.Length;
         }
 
         public FloatArrayPacket(float[] value, Timestamp timestamp) : base()
         {
-            nf.UnsafeNativeMethods.mp__MakeFloatArrayPacket_At__Pf_i_Rt(value, value.Length, timestamp.MpPtr, out var ptr).Assert();
+            UnsafeNativeMethods.mp__MakeFloatArrayPacket_At__Pf_i_Rt(value, value.Length, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
-            this.Ptr = ptr;
+            Ptr = ptr;
             Length = value.Length;
         }
 
@@ -74,7 +67,7 @@ namespace Akihabara.Framework.Packet
 
         public IntPtr GetArrayPtr()
         {
-            nf.UnsafeNativeMethods.mp_Packet__GetFloatArray(MpPtr, out var value).Assert();
+            UnsafeNativeMethods.mp_Packet__GetFloatArray(MpPtr, out var value).Assert();
             GC.KeepAlive(this);
             return value;
         }
@@ -86,7 +79,7 @@ namespace Akihabara.Framework.Packet
 
         public override Status ValidateAsType()
         {
-            nf.UnsafeNativeMethods.mp_Packet__ValidateAsFloatArray(MpPtr, out var statusPtr).Assert();
+            UnsafeNativeMethods.mp_Packet__ValidateAsFloatArray(MpPtr, out var statusPtr).Assert();
 
             GC.KeepAlive(this);
             return new Status(statusPtr);

--- a/src/Akihabara/Framework/Packet/FloatPacket.cs
+++ b/src/Akihabara/Framework/Packet/FloatPacket.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Framework.Port;
@@ -18,14 +17,14 @@ namespace Akihabara.Framework.Packet
         public FloatPacket(float value) : base()
         {
             UnsafeNativeMethods.mp__MakeFloatPacket__f(value, out var ptr).Assert();
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public FloatPacket(float value, Timestamp timestamp) : base()
         {
             UnsafeNativeMethods.mp__MakeFloatPacket_At__f_Rt(value, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public override float Get()

--- a/src/Akihabara/Framework/Packet/GpuBufferPacket.cs
+++ b/src/Akihabara/Framework/Packet/GpuBufferPacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.Gpu;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using  ng = Akihabara.Native.Gpu;
 using Akihabara.Framework.Port;
+using Akihabara.Gpu;
 using Akihabara.Native;
+using UnsafeNativeMethods = Akihabara.Native.Gpu.UnsafeNativeMethods;
 
 namespace Akihabara.Framework.Packet
 {
@@ -21,24 +16,24 @@ namespace Akihabara.Framework.Packet
 
         public GpuBufferPacket(GpuBuffer gpuBuffer) : base()
         {
-            ng.UnsafeNativeMethods.mp__MakeGpuBufferPacket__Rgb(gpuBuffer.MpPtr, out var ptr).Assert();
+            UnsafeNativeMethods.mp__MakeGpuBufferPacket__Rgb(gpuBuffer.MpPtr, out var ptr).Assert();
             gpuBuffer.Dispose(); // respect move semantics
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public GpuBufferPacket(GpuBuffer gpuBuffer, Timestamp timestamp)
         {
-            ng.UnsafeNativeMethods.mp__MakeGpuBufferPacket_At__Rgb_Rts(gpuBuffer.MpPtr, timestamp.MpPtr, out var ptr).Assert();
+            UnsafeNativeMethods.mp__MakeGpuBufferPacket_At__Rgb_Rts(gpuBuffer.MpPtr, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
             gpuBuffer.Dispose(); // respect move semantics
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public override GpuBuffer Get()
         {
-            ng.UnsafeNativeMethods.mp_Packet__GetGpuBuffer(MpPtr, out var gpuBufferPtr).Assert();
+            UnsafeNativeMethods.mp_Packet__GetGpuBuffer(MpPtr, out var gpuBufferPtr).Assert();
 
             GC.KeepAlive(this);
             return new GpuBuffer(gpuBufferPtr, false);
@@ -46,7 +41,7 @@ namespace Akihabara.Framework.Packet
 
         public override StatusOr<GpuBuffer> Consume()
         {
-            ng.UnsafeNativeMethods.mp_Packet__ConsumeGpuBuffer(MpPtr, out var statusOrGpuBufferPtr).Assert();
+            UnsafeNativeMethods.mp_Packet__ConsumeGpuBuffer(MpPtr, out var statusOrGpuBufferPtr).Assert();
 
             GC.KeepAlive(this);
             return new StatusOrGpuBuffer(statusOrGpuBufferPtr);
@@ -54,7 +49,7 @@ namespace Akihabara.Framework.Packet
 
         public override Status ValidateAsType()
         {
-            ng.UnsafeNativeMethods.mp_Packet__ValidateAsGpuBuffer(MpPtr, out var statusPtr).Assert();
+            UnsafeNativeMethods.mp_Packet__ValidateAsGpuBuffer(MpPtr, out var statusPtr).Assert();
 
             GC.KeepAlive(this);
             return new Status(statusPtr);

--- a/src/Akihabara/Framework/Packet/ImageFramePacket.cs
+++ b/src/Akihabara/Framework/Packet/ImageFramePacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
+using System;
 using Akihabara.Framework.ImageFormat;
 using Akihabara.Framework.Port;
-using ff = Akihabara.Native.Framework.Format;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Akihabara.Native;
+using UnsafeNativeMethods = Akihabara.Native.Framework.Format.UnsafeNativeMethods;
 
 namespace Akihabara.Framework.Packet
 {
@@ -22,24 +17,24 @@ namespace Akihabara.Framework.Packet
 
         public ImageFramePacket(ImageFrame imageFrame) : base()
         {
-            ff.UnsafeNativeMethods.mp__MakeImageFramePacket__Pif(imageFrame.MpPtr, out var ptr).Assert();
+            UnsafeNativeMethods.mp__MakeImageFramePacket__Pif(imageFrame.MpPtr, out var ptr).Assert();
             imageFrame.Dispose(); // respect move semantics
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public ImageFramePacket(ImageFrame imageFrame, Timestamp timestamp) : base()
         {
-            ff.UnsafeNativeMethods.mp__MakeImageFramePacket_At__Pif_Rt(imageFrame.MpPtr, timestamp.MpPtr, out var ptr).Assert();
+            UnsafeNativeMethods.mp__MakeImageFramePacket_At__Pif_Rt(imageFrame.MpPtr, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
             imageFrame.Dispose(); // respect move semantics
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public override ImageFrame Get()
         {
-            ff.UnsafeNativeMethods.mp_Packet__GetImageFrame(MpPtr, out var imageFramePtr).Assert();
+            UnsafeNativeMethods.mp_Packet__GetImageFrame(MpPtr, out var imageFramePtr).Assert();
 
             GC.KeepAlive(this);
             return new ImageFrame(imageFramePtr, false);
@@ -47,7 +42,7 @@ namespace Akihabara.Framework.Packet
 
         public override StatusOr<ImageFrame> Consume()
         {
-            ff.UnsafeNativeMethods.mp_Packet__ConsumeImageFrame(MpPtr, out var statusOrImageFramePtr).Assert();
+            UnsafeNativeMethods.mp_Packet__ConsumeImageFrame(MpPtr, out var statusOrImageFramePtr).Assert();
 
             GC.KeepAlive(this);
             return new StatusOrImageFrame(statusOrImageFramePtr);
@@ -55,7 +50,7 @@ namespace Akihabara.Framework.Packet
 
         public override Status ValidateAsType()
         {
-            ff.UnsafeNativeMethods.mp_Packet__ValidateAsImageFrame(MpPtr, out var statusPtr).Assert();
+            UnsafeNativeMethods.mp_Packet__ValidateAsImageFrame(MpPtr, out var statusPtr).Assert();
 
             GC.KeepAlive(this);
             return new Status(statusPtr);

--- a/src/Akihabara/Framework/Packet/IntPacket.cs
+++ b/src/Akihabara/Framework/Packet/IntPacket.cs
@@ -1,15 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.Native;
-using nf = Akihabara.Native.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Akihabara.Framework.Port;
+using Akihabara.Native;
+using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
 
 namespace Akihabara.Framework.Packet
 {
@@ -21,20 +16,20 @@ namespace Akihabara.Framework.Packet
 
         public IntPacket(int value) : base()
         {
-            nf.UnsafeNativeMethods.mp__MakeIntPacket__i(value, out var ptr).Assert();
-            this.Ptr = ptr;
+            UnsafeNativeMethods.mp__MakeIntPacket__i(value, out var ptr).Assert();
+            Ptr = ptr;
         }
 
         public IntPacket(int value, Timestamp timestamp) : base()
         {
-            nf.UnsafeNativeMethods.mp__MakeIntPacket_At__i_Rt(value, timestamp.MpPtr, out var ptr).Assert();
+            UnsafeNativeMethods.mp__MakeIntPacket_At__i_Rt(value, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public override int Get()
         {
-            nf.UnsafeNativeMethods.mp_Packet__GetInt(MpPtr, out var value).Assert();
+            UnsafeNativeMethods.mp_Packet__GetInt(MpPtr, out var value).Assert();
 
             GC.KeepAlive(this);
             return value;
@@ -47,7 +42,7 @@ namespace Akihabara.Framework.Packet
 
         public override Status ValidateAsType()
         {
-            nf.UnsafeNativeMethods.mp_Packet__ValidateAsInt(MpPtr, out var statusPtr).Assert();
+            UnsafeNativeMethods.mp_Packet__ValidateAsInt(MpPtr, out var statusPtr).Assert();
 
             GC.KeepAlive(this);
             return new Status(statusPtr);

--- a/src/Akihabara/Framework/Packet/LandmarkListPacket.cs
+++ b/src/Akihabara/Framework/Packet/LandmarkListPacket.cs
@@ -1,16 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/LandmarkListVectorPacket.cs
+++ b/src/Akihabara/Framework/Packet/LandmarkListVectorPacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
+using System.Collections.Generic;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/NormalizedLandmarkListPacket.cs
+++ b/src/Akihabara/Framework/Packet/NormalizedLandmarkListPacket.cs
@@ -1,16 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
+++ b/src/Akihabara/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
+using System.Collections.Generic;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/NormalizedRectPacket.cs
+++ b/src/Akihabara/Framework/Packet/NormalizedRectPacket.cs
@@ -1,16 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/NormalizedRectVectorPacket.cs
+++ b/src/Akihabara/Framework/Packet/NormalizedRectVectorPacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
+using System.Collections.Generic;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/Packet.cs
+++ b/src/Akihabara/Framework/Packet/Packet.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -15,7 +14,7 @@ namespace Akihabara.Framework.Packet
         public Packet() : base()
         {
             UnsafeNativeMethods.mp_Packet__(out var ptr);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public Packet(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner)
@@ -32,7 +31,7 @@ namespace Akihabara.Framework.Packet
 
             GC.KeepAlive(timestamp);
 
-            return (Packet<T>)Activator.CreateInstance(this.GetType(), packetPtr, true);
+            return (Packet<T>)Activator.CreateInstance(GetType(), packetPtr, true);
         }
 
         public Status ValidateAsProtoMessageLite()

--- a/src/Akihabara/Framework/Packet/RectPacket.cs
+++ b/src/Akihabara/Framework/Packet/RectPacket.cs
@@ -1,16 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/RectVectorPacket.cs
+++ b/src/Akihabara/Framework/Packet/RectVectorPacket.cs
@@ -1,16 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
-using Akihabara.External;
+using System;
+using System.Collections.Generic;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Packet/SidePacket.cs
+++ b/src/Akihabara/Framework/Packet/SidePacket.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -13,7 +12,7 @@ namespace Akihabara.Framework.Packet
         public SidePacket() : base()
         {
             UnsafeNativeMethods.mp_SidePacket__(out var ptr);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         protected override void DeleteMpPtr()

--- a/src/Akihabara/Framework/Packet/StringPacket.cs
+++ b/src/Akihabara/Framework/Packet/StringPacket.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -19,27 +18,27 @@ namespace Akihabara.Framework.Packet
         public StringPacket(string value) : base()
         {
             UnsafeNativeMethods.mp__MakeStringPacket__PKc(value, out var ptr).Assert();
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public StringPacket(byte[] bytes) : base()
         {
             UnsafeNativeMethods.mp__MakeStringPacket__PKc_i(bytes, bytes.Length, out var ptr).Assert();
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public StringPacket(string value, Timestamp timestamp) : base()
         {
             UnsafeNativeMethods.mp__MakeStringPacket_At__PKc_Rt(value, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public StringPacket(byte[] bytes, Timestamp timestamp) : base()
         {
             UnsafeNativeMethods.mp__MakeStringPacket_At__PKc_i_Rt(bytes, bytes.Length, timestamp.MpPtr, out var ptr).Assert();
             GC.KeepAlive(timestamp);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public override string Get()

--- a/src/Akihabara/Framework/Packet/TimedModelMatrixProtoListPacket.cs
+++ b/src/Akihabara/Framework/Packet/TimedModelMatrixProtoListPacket.cs
@@ -1,11 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
+using System;
 using Akihabara.Framework.Port;
 using Akihabara.Framework.Protobuf;
 using Akihabara.Native;
-using System;
 
 namespace Akihabara.Framework.Packet
 {

--- a/src/Akihabara/Framework/Port/Status.cs
+++ b/src/Akihabara/Framework/Port/Status.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;

--- a/src/Akihabara/Framework/Port/StatusOr.cs
+++ b/src/Akihabara/Framework/Port/StatusOr.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;

--- a/src/Akihabara/Framework/Port/StatusOrGpuBuffer.cs
+++ b/src/Akihabara/Framework/Port/StatusOrGpuBuffer.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Gpu;
@@ -19,15 +18,12 @@ namespace Akihabara.Framework.Port
             UnsafeNativeMethods.mp_StatusOrGpuBuffer__delete(Ptr);
         }
 
-        public override bool Ok
-        {
+        public override bool Ok {
             get { return SafeNativeMethods.mp_StatusOrGpuBuffer__ok(MpPtr); }
         }
 
-        public override Status Status
-        {
-            get
-            {
+        public override Status Status {
+            get {
                 UnsafeNativeMethods.mp_StatusOrGpuBuffer__status(MpPtr, out var statusPtr).Assert();
 
                 GC.KeepAlive(this);

--- a/src/Akihabara/Framework/Port/StatusOrGpuResources.cs
+++ b/src/Akihabara/Framework/Port/StatusOrGpuResources.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Gpu;
@@ -21,10 +20,8 @@ namespace Akihabara.Framework.Port
 
         public override bool Ok => SafeNativeMethods.mp_StatusOrGpuBuffer__ok(MpPtr);
 
-        public override Status Status
-        {
-            get
-            {
+        public override Status Status {
+            get {
                 UnsafeNativeMethods.mp_StatusOrGpuResources__status(MpPtr, out var statusPtr).Assert();
 
                 GC.KeepAlive(this);

--- a/src/Akihabara/Framework/Port/StatusOrImageFrame.cs
+++ b/src/Akihabara/Framework/Port/StatusOrImageFrame.cs
@@ -1,12 +1,11 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
-using Akihabara.Native;
 using Akihabara.Framework.ImageFormat;
-using UnsafeNativeMethods = Akihabara.Native.Framework.Format.UnsafeNativeMethods;
+using Akihabara.Native;
 using SafeNativeMethods = Akihabara.Native.Framework.Format.SafeNativeMethods;
+using UnsafeNativeMethods = Akihabara.Native.Framework.Format.UnsafeNativeMethods;
 
 namespace Akihabara.Framework.Port
 {
@@ -19,15 +18,12 @@ namespace Akihabara.Framework.Port
             UnsafeNativeMethods.mp_StatusOrImageFrame__delete(Ptr);
         }
 
-        public override bool Ok
-        {
+        public override bool Ok {
             get { return SafeNativeMethods.mp_StatusOrImageFrame__ok(MpPtr); }
         }
 
-        public override Status Status
-        {
-            get
-            {
+        public override Status Status {
+            get {
                 UnsafeNativeMethods.mp_StatusOrImageFrame__status(MpPtr, out var statusPtr).Assert();
 
                 GC.KeepAlive(this);

--- a/src/Akihabara/Framework/Port/StatusOrPoller.cs
+++ b/src/Akihabara/Framework/Port/StatusOrPoller.cs
@@ -1,12 +1,10 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
-
 using Akihabara.Native;
-using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
 using SafeNativeMethods = Akihabara.Native.Framework.SafeNativeMethods;
+using UnsafeNativeMethods = Akihabara.Native.Framework.UnsafeNativeMethods;
 
 namespace Akihabara.Framework.Port
 {
@@ -21,15 +19,12 @@ namespace Akihabara.Framework.Port
             UnsafeNativeMethods.mp_StatusOrPoller__delete(Ptr);
         }
 
-        public override bool Ok
-        {
+        public override bool Ok {
             get { return SafeNativeMethods.mp_StatusOrPoller__ok(MpPtr); }
         }
 
-        public override Status Status
-        {
-            get
-            {
+        public override Status Status {
+            get {
                 UnsafeNativeMethods.mp_StatusOrPoller__status(MpPtr, out var statusPtr).Assert();
 
                 GC.KeepAlive(this);

--- a/src/Akihabara/Framework/Timestamp.cs
+++ b/src/Akihabara/Framework/Timestamp.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -19,7 +18,7 @@ namespace Akihabara.Framework
         public Timestamp(long val) : base()
         {
             UnsafeNativeMethods.mp_Timestamp__l(val, out var ptr);
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         protected override void DeleteMpPtr()
@@ -35,7 +34,7 @@ namespace Akihabara.Framework
             return Microseconds() == other.Microseconds();
         }
 
-        public override bool Equals(Object obj)
+        public override bool Equals(object obj)
         {
             Timestamp timestampObj = obj == null ? null : (obj as Timestamp);
 
@@ -64,7 +63,7 @@ namespace Akihabara.Framework
 
         public override int GetHashCode()
         {
-            return this.Microseconds().GetHashCode();
+            return Microseconds().GetHashCode();
         }
         #endregion
 

--- a/src/Akihabara/Gpu/EglSurfaceHolder.cs
+++ b/src/Akihabara/Gpu/EglSurfaceHolder.cs
@@ -1,12 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
-
-using Akihabara.Core;
-using Akihabara.Native;
-using UnsafeNativeMethods = Akihabara.Native.Gpu.UnsafeNativeMethods;
-using SafeNativeMethods = Akihabara.Native.Gpu.SafeNativeMethods;
-using System;
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 namespace Akihabara.Gpu
 {

--- a/src/Akihabara/Gpu/GL.cs
+++ b/src/Akihabara/Gpu/GL.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Native.Gpu;

--- a/src/Akihabara/Gpu/GLCalculatorHelper.cs
+++ b/src/Akihabara/Gpu/GLCalculatorHelper.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -23,7 +22,7 @@ namespace Akihabara.Gpu
         {
             UnsafeNativeMethods.mp_GlCalculatorHelper__(out var ptr).Assert();
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         protected override void DeleteMpPtr()

--- a/src/Akihabara/Gpu/GLContext.cs
+++ b/src/Akihabara/Gpu/GLContext.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -24,7 +23,7 @@ namespace Akihabara.Gpu
         public GlContext(IntPtr ptr, bool isOwner = true) : base(isOwner)
         {
             _sharedPtrHandle = new GlContextSharedPtr(ptr);
-            this.Ptr = _sharedPtrHandle.Get();
+            Ptr = _sharedPtrHandle.Get();
         }
 
         protected override void DisposeManaged()
@@ -46,7 +45,7 @@ namespace Akihabara.Gpu
 
         public IntPtr SharedPtr => _sharedPtrHandle?.MpPtr ?? IntPtr.Zero;
 
-        #if OPENGL_ES
+#if OPENGL_ES
         public IntPtr EglDisplay => SafeNativeMethods.mp_GlContext__egl_display(MpPtr);
 
         public IntPtr EglConfig => SafeNativeMethods.mp_GlContext__egl_config(MpPtr);
@@ -56,7 +55,7 @@ namespace Akihabara.Gpu
         public IntPtr NsglContext => SafeNativeMethods.mp_GlContext__nsgl_context(MpPtr);
 
         public IntPtr EaglContext => SafeNativeMethods.mp_GlContext__eagl_context(MpPtr);
-        #endif
+#endif
 
         public bool IsCurrent => SafeNativeMethods.mp_GlContext__IsCurrent(MpPtr);
 

--- a/src/Akihabara/Gpu/GLSyncPoint.cs
+++ b/src/Akihabara/Gpu/GLSyncPoint.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -18,7 +17,7 @@ namespace Akihabara.Gpu
         {
             _sharedPtrHandle = new GlSyncPointSharedPtr(ptr);
 
-            this.Ptr = _sharedPtrHandle.Get();
+            Ptr = _sharedPtrHandle.Get();
         }
 
         protected override void DisposeManaged()

--- a/src/Akihabara/Gpu/GLTexture.cs
+++ b/src/Akihabara/Gpu/GLTexture.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -16,14 +15,14 @@ namespace Akihabara.Gpu
         {
             UnsafeNativeMethods.mp_GlTexture__(out var ptr).Assert();
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public GlTexture(uint name, int width, int height) : base()
         {
             UnsafeNativeMethods.mp_GlTexture__ui_i_i(name, width, height, out var ptr).Assert();
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         public GlTexture(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/src/Akihabara/Gpu/GLTextureBuffer.cs
+++ b/src/Akihabara/Gpu/GLTextureBuffer.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -28,7 +27,7 @@ namespace Akihabara.Gpu
         {
             _sharedPtrHandle = new GlTextureBufferSharedPtr(ptr, isOwner);
 
-            this.Ptr = _sharedPtrHandle.Get();
+            Ptr = _sharedPtrHandle.Get();
         }
 
         public GlTextureBuffer(uint target, uint name, int width, int height, GpuBufferFormat format,

--- a/src/Akihabara/Gpu/GLTextureInfo.cs
+++ b/src/Akihabara/Gpu/GLTextureInfo.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System.Runtime.InteropServices;
 

--- a/src/Akihabara/Gpu/GLVersion.cs
+++ b/src/Akihabara/Gpu/GLVersion.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 namespace Akihabara.Gpu
 {

--- a/src/Akihabara/Gpu/GpuBuffer.cs
+++ b/src/Akihabara/Gpu/GpuBuffer.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -19,7 +18,7 @@ namespace Akihabara.Gpu
             UnsafeNativeMethods.mp_GpuBuffer__PSgtb(glTextureBuffer.SharedPtr, out var ptr).Assert();
             glTextureBuffer.Dispose();
 
-            this.Ptr = ptr;
+            Ptr = ptr;
         }
 
         protected override void DeleteMpPtr() => UnsafeNativeMethods.mp_GpuBuffer__delete(Ptr);

--- a/src/Akihabara/Gpu/GpuBufferFormat.cs
+++ b/src/Akihabara/Gpu/GpuBufferFormat.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System.Runtime.InteropServices;
 using Akihabara.Framework.ImageFormat;

--- a/src/Akihabara/Gpu/GpuResources.cs
+++ b/src/Akihabara/Gpu/GpuResources.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;
@@ -19,7 +18,7 @@ namespace Akihabara.Gpu
         {
             _sharedPtrHandle = new GpuResourceSharedPtr(ptr);
 
-            this.Ptr = _sharedPtrHandle.Get();
+            Ptr = _sharedPtrHandle.Get();
         }
 
         protected override void DisposeManaged()

--- a/src/Akihabara/Gpu/ISharedPtr.cs
+++ b/src/Akihabara/Gpu/ISharedPtr.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 

--- a/src/Akihabara/Gpu/SharedPtr.cs
+++ b/src/Akihabara/Gpu/SharedPtr.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using Akihabara.Core;

--- a/src/Akihabara/Native/Framework/Format/SafeImageFrame.cs
+++ b/src/Akihabara/Native/Framework/Format/SafeImageFrame.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;
@@ -21,7 +20,7 @@ namespace Akihabara.Native.Framework.Format
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__IsAligned__ui(
-            IntPtr imageFrame, UInt32 alignmentBoundary, [MarshalAs(UnmanagedType.I1)] out bool value);
+            IntPtr imageFrame, uint alignmentBoundary, [MarshalAs(UnmanagedType.I1)] out bool value);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern ImageFormat.Format mp_ImageFrame__Format(IntPtr imageFrame);

--- a/src/Akihabara/Native/Framework/Format/UnsafeImageFrame.cs
+++ b/src/Akihabara/Native/Framework/Format/UnsafeImageFrame.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -15,7 +14,7 @@ namespace Akihabara.Native.Framework.Format
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_ui(
-            ImageFormat.Format format, int width, int height, UInt32 alignmentBoundary, out IntPtr imageFrame);
+            ImageFormat.Format format, int width, int height, uint alignmentBoundary, out IntPtr imageFrame);
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern MpReturnCode mp_ImageFrame__ui_i_i_i_Pui8_PF(

--- a/src/Akihabara/Native/Framework/SafeCalculatorGraph.cs
+++ b/src/Akihabara/Native/Framework/SafeCalculatorGraph.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/Framework/SafeOutputStreamPoller.cs
+++ b/src/Akihabara/Native/Framework/SafeOutputStreamPoller.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/Framework/SafePacket.cs
+++ b/src/Akihabara/Native/Framework/SafePacket.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Framework/SafeTimestamp.cs
+++ b/src/Akihabara/Native/Framework/SafeTimestamp.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;
@@ -11,13 +10,13 @@ namespace Akihabara.Native.Framework
     public partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern Int64 mp_Timestamp__Value(IntPtr timestamp);
+        public static extern long mp_Timestamp__Value(IntPtr timestamp);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern double mp_Timestamp__Seconds(IntPtr timestamp);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern Int64 mp_Timestamp__Microseconds(IntPtr timestamp);
+        public static extern long mp_Timestamp__Microseconds(IntPtr timestamp);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.I1)]

--- a/src/Akihabara/Native/Framework/UnsafeCalculator.cs
+++ b/src/Akihabara/Native/Framework/UnsafeCalculator.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Framework/UnsafeCalculatorGraph.cs
+++ b/src/Akihabara/Native/Framework/UnsafeCalculatorGraph.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Framework/UnsafeOutputStreamPoller.cs
+++ b/src/Akihabara/Native/Framework/UnsafeOutputStreamPoller.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Framework/UnsafePacket.cs
+++ b/src/Akihabara/Native/Framework/UnsafePacket.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Framework/UnsafeTimestamp.cs
+++ b/src/Akihabara/Native/Framework/UnsafeTimestamp.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -10,7 +9,7 @@ namespace Akihabara.Native.Framework
     public partial class UnsafeNativeMethods : NativeMethods
     {
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern MpReturnCode mp_Timestamp__l(Int64 value, out IntPtr timestamp);
+        public static extern MpReturnCode mp_Timestamp__l(long value, out IntPtr timestamp);
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern void mp_Timestamp__delete(IntPtr timestamp);

--- a/src/Akihabara/Native/Gpu/SafeEglSurfaceHolder.cs
+++ b/src/Akihabara/Native/Gpu/SafeEglSurfaceHolder.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/Gpu/SafeGL.cs
+++ b/src/Akihabara/Native/Gpu/SafeGL.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/Gpu/SafeGlCalculatorHelper.cs
+++ b/src/Akihabara/Native/Gpu/SafeGlCalculatorHelper.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;
@@ -11,7 +10,7 @@ namespace Akihabara.Native.Gpu
     public partial class SafeNativeMethods : NativeMethods
     {
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern UInt32 mp_GlCalculatorHelper__framebuffer(IntPtr glCalculatorHelper);
+        public static extern uint mp_GlCalculatorHelper__framebuffer(IntPtr glCalculatorHelper);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern IntPtr mp_GlCalculatorHelper__GetGlContext(IntPtr glCalculatorHelper);

--- a/src/Akihabara/Native/Gpu/SafeGlContext.cs
+++ b/src/Akihabara/Native/Gpu/SafeGlContext.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/Gpu/SafeGlTexture.cs
+++ b/src/Akihabara/Native/Gpu/SafeGlTexture.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;
@@ -17,9 +16,9 @@ namespace Akihabara.Native.Gpu
         public static extern int mp_GlTexture__height(IntPtr glTexture);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern UInt32 mp_GlTexture__target(IntPtr glTexture);
+        public static extern uint mp_GlTexture__target(IntPtr glTexture);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern UInt32 mp_GlTexture__name(IntPtr glTexture);
+        public static extern uint mp_GlTexture__name(IntPtr glTexture);
     }
 }

--- a/src/Akihabara/Native/Gpu/SafeGlTextureBuffer.cs
+++ b/src/Akihabara/Native/Gpu/SafeGlTextureBuffer.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;
@@ -13,10 +12,10 @@ namespace Akihabara.Native.Gpu
     {
         #region GlTextureBuffer
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern UInt32 mp_GlTextureBuffer__name(IntPtr glTextureBuffer);
+        public static extern uint mp_GlTextureBuffer__name(IntPtr glTextureBuffer);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern UInt32 mp_GlTextureBuffer__target(IntPtr glTextureBuffer);
+        public static extern uint mp_GlTextureBuffer__target(IntPtr glTextureBuffer);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern int mp_GlTextureBuffer__width(IntPtr glTextureBuffer);

--- a/src/Akihabara/Native/Gpu/SafeGpuBuffer.cs
+++ b/src/Akihabara/Native/Gpu/SafeGpuBuffer.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/Gpu/SafeGpuBufferFormat.cs
+++ b/src/Akihabara/Native/Gpu/SafeGpuBufferFormat.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Gpu/SafeGpuResources.cs
+++ b/src/Akihabara/Native/Gpu/SafeGpuResources.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/Gpu/UnsafeEglSurfaceHolder.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeEglSurfaceHolder.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Gpu/UnsafeGL.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGL.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -13,7 +12,7 @@ namespace Akihabara.Native.Gpu
         public static extern void glFlush();
 
         [DllImport(MediaPipeLibrary)]
-        public static extern void glReadPixels(int x, int y, int width, int height, UInt32 glFormat, UInt32 glType,
+        public static extern void glReadPixels(int x, int y, int width, int height, uint glFormat, uint glType,
             IntPtr pixels);
     }
 }

--- a/src/Akihabara/Native/Gpu/UnsafeGlCalculatorHelper.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGlCalculatorHelper.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Gpu/UnsafeGlContext.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGlContext.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -30,7 +29,7 @@ namespace Akihabara.Native.Gpu
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern MpReturnCode mp_GlContext_Create__ui_b(
-            UInt32 shareContext, [MarshalAs(UnmanagedType.I1)] bool createThread, out IntPtr statusOrSharedGlContext);
+            uint shareContext, [MarshalAs(UnmanagedType.I1)] bool createThread, out IntPtr statusOrSharedGlContext);
 
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]

--- a/src/Akihabara/Native/Gpu/UnsafeGlTexture.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGlTexture.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -14,7 +13,7 @@ namespace Akihabara.Native.Gpu
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern MpReturnCode
-            mp_GlTexture__ui_i_i(UInt32 name, int width, int height, out IntPtr glTexture);
+            mp_GlTexture__ui_i_i(uint name, int width, int height, out IntPtr glTexture);
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern void mp_GlTexture__delete(IntPtr glTexture);

--- a/src/Akihabara/Native/Gpu/UnsafeGlTextureBuffer.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGlTextureBuffer.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;
@@ -45,7 +44,7 @@ namespace Akihabara.Native.Gpu
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
         public static extern MpReturnCode mp_SharedGlTextureBuffer__ui_ui_i_i_ui_PF_PSgc(
-            UInt32 target, UInt32 name, int width, int height, GpuBufferFormat format,
+            uint target, uint name, int width, int height, GpuBufferFormat format,
             [MarshalAs(UnmanagedType.FunctionPtr)] GlTextureBuffer.DeletionCallback deletionCallback,
             IntPtr producerContext, out IntPtr sharedGlTextureBuffer);
 

--- a/src/Akihabara/Native/Gpu/UnsafeGpuBuffer.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGpuBuffer.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Gpu/UnsafeGpuBufferFormat.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGpuBufferFormat.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/Gpu/UnsafeGpuResources.cs
+++ b/src/Akihabara/Native/Gpu/UnsafeGpuResources.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Akihabara/Native/MpReturnCode.cs
+++ b/src/Akihabara/Native/MpReturnCode.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using Akihabara.Core;
 

--- a/src/Akihabara/Native/NativeMethods.cs
+++ b/src/Akihabara/Native/NativeMethods.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 namespace Akihabara.Native
 {

--- a/src/Akihabara/Native/SafeNativeMethods.cs
+++ b/src/Akihabara/Native/SafeNativeMethods.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Akihabara/Native/UnsafeNativeMethods.cs
+++ b/src/Akihabara/Native/UnsafeNativeMethods.cs
@@ -1,6 +1,5 @@
-// Copyright 2021 (c) homuler and The Vignette Authors
-// Licensed under MIT
-// See LICENSE for details
+// Copyright (c) homuler & The Vignette Authors. Licensed under the MIT license.
+// See the LICENSE file in the repository root for more details.
 
 using System;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
Apparently GitHub is stupid and closes a PR if the branch changes name.
Quoting the PR body from #17

> Fixed stuff:

> - [x] Removed unnecessary usings
> - [x] Used consistent naming
> - [x] Removed unnecessary casts
> - [x] Removed unnecessary `this.`
> - [x] Ordered the usings