### PR TITLE
fix: Marshal boolean as UnmanagedType.I1

### DIFF
--- a/src/Akihabara/Native/Gpu/SafeEglSurfaceHolder.cs
+++ b/src/Akihabara/Native/Gpu/SafeEglSurfaceHolder.cs
@@ -22,7 +22,7 @@ namespace Akihabara.Native.Gpu
         public static extern bool mp_EglSurfaceHolder__flip_y(IntPtr eglSurfaceHolder);
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]
-        public static extern void mp_EglSurfaceHolder__SetFlipY__b(IntPtr eglSurfaceHolder, bool flipY);
+        public static extern void mp_EglSurfaceHolder__SetFlipY__b(IntPtr eglSurfaceHolder, [MarshalAs(UnmanagedType.I1)] bool flipY);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.I1)]

--- a/src/Akihabara/Native/SafeNativeMethods.cs
+++ b/src/Akihabara/Native/SafeNativeMethods.cs
@@ -12,6 +12,7 @@ namespace Akihabara.Native
         #region ABSL
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool absl_Status__ok(IntPtr status);
 
         [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]


### PR DESCRIPTION
I checked CI errors and found a bug.
It seems that I forgot to add `MarshalAsAttribute` to boolean values in 2 lines.

I found another bug in Status API (`ToString_ShouldReturnMessage_When_StatusIsFailedPrecondition` is failing in CI tests), but it's up to the project to decide how to fix this problem, so this PR does not fix it (and I think #29 will fix it).
To note the cause, the following two lines are contradictory.
https://github.com/vignetteapp/Akihabara/blob/366a799c98138ea4564f15829dc10a042479b9f6/src/Akihabara/Native/UnsafeNativeMethods.cs#L20
https://github.com/vignetteapp/Akihabara/blob/366a799c98138ea4564f15829dc10a042479b9f6/src/Akihabara/Core/MpResourceHandle.cs#L78