### PR TITLE
fix: ImageFrame test

### DIFF
--- a/src/Akihabara.Tests/Framework/ImageFormat/ImageFrameTest.cs
+++ b/src/Akihabara.Tests/Framework/ImageFormat/ImageFrameTest.cs
@@ -17,51 +17,54 @@ namespace Akihabara.Tests.Format
         [Test, SignalAbort]
         public void Ctor_ShouldInstantiateImageFrame_When_CalledWithNoArguments()
         {
-            var imageFrame = new ImageFrame();
-
-            Assert.AreEqual(imageFrame.Format(), ImageFormat.Format.Unknown);
-            Assert.AreEqual(imageFrame.Width(), 0);
-            Assert.AreEqual(imageFrame.Height(), 0);
-            Assert.Throws<FormatException>(() => { imageFrame.ChannelSize(); });
-            Assert.Throws<FormatException>(() => { imageFrame.NumberOfChannels(); });
-            Assert.Throws<FormatException>(() => { imageFrame.ByteDepth(); });
-            Assert.AreEqual(imageFrame.WidthStep(), 0);
-            Assert.AreEqual(imageFrame.PixelDataSize(), 0);
-            Assert.Throws<FormatException>(() => { imageFrame.PixelDataSizeStoredContiguously(); });
-            Assert.True(imageFrame.IsEmpty());
-            Assert.False(imageFrame.IsContiguous());
-            Assert.False(imageFrame.IsAligned(16));
-            Assert.AreEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+            using (var imageFrame = new ImageFrame())
+            {
+                Assert.AreEqual(imageFrame.Format(), ImageFormat.Format.Unknown);
+                Assert.AreEqual(imageFrame.Width(), 0);
+                Assert.AreEqual(imageFrame.Height(), 0);
+                Assert.Throws<FormatException>(() => { imageFrame.ChannelSize(); });
+                Assert.Throws<FormatException>(() => { imageFrame.NumberOfChannels(); });
+                Assert.Throws<FormatException>(() => { imageFrame.ByteDepth(); });
+                Assert.AreEqual(imageFrame.WidthStep(), 0);
+                Assert.AreEqual(imageFrame.PixelDataSize(), 0);
+                Assert.Throws<FormatException>(() => { imageFrame.PixelDataSizeStoredContiguously(); });
+                Assert.True(imageFrame.IsEmpty());
+                Assert.False(imageFrame.IsContiguous());
+                Assert.False(imageFrame.IsAligned(16));
+                Assert.AreEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+            }
         }
 
         [Test]
         public void Ctor_ShouldInstantiateImageFrame_When_CalledWithFormat()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Sbgra, 640, 480);
-
-            Assert.AreEqual(imageFrame.Format(), ImageFormat.Format.Sbgra);
-            Assert.AreEqual(imageFrame.Width(), 640);
-            Assert.AreEqual(imageFrame.Height(), 480);
-            Assert.AreEqual(imageFrame.ChannelSize(), 1);
-            Assert.AreEqual(imageFrame.NumberOfChannels(), 4);
-            Assert.AreEqual(imageFrame.ByteDepth(), 1);
-            Assert.AreEqual(imageFrame.WidthStep(), 640 * 4);
-            Assert.AreEqual(imageFrame.PixelDataSize(), 640 * 480 * 4);
-            Assert.AreEqual(imageFrame.PixelDataSizeStoredContiguously(), 640 * 480 * 4);
-            Assert.False(imageFrame.IsEmpty());
-            Assert.True(imageFrame.IsContiguous());
-            Assert.True(imageFrame.IsAligned(16));
-            Assert.AreNotEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Sbgra, 640, 480))
+            {
+                Assert.AreEqual(imageFrame.Format(), ImageFormat.Format.Sbgra);
+                Assert.AreEqual(imageFrame.Width(), 640);
+                Assert.AreEqual(imageFrame.Height(), 480);
+                Assert.AreEqual(imageFrame.ChannelSize(), 1);
+                Assert.AreEqual(imageFrame.NumberOfChannels(), 4);
+                Assert.AreEqual(imageFrame.ByteDepth(), 1);
+                Assert.AreEqual(imageFrame.WidthStep(), 640 * 4);
+                Assert.AreEqual(imageFrame.PixelDataSize(), 640 * 480 * 4);
+                Assert.AreEqual(imageFrame.PixelDataSizeStoredContiguously(), 640 * 480 * 4);
+                Assert.False(imageFrame.IsEmpty());
+                Assert.True(imageFrame.IsContiguous());
+                Assert.True(imageFrame.IsAligned(16));
+                Assert.AreNotEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+            }
         }
 
         [Test]
         public void Ctor_ShouldInstantiateImageFrame_When_CalledWithFormatAndAlignmentBoundary()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 100, 100, 8);
-
-            Assert.AreEqual(imageFrame.Width(), 100);
-            Assert.AreEqual(imageFrame.NumberOfChannels(), 1);
-            Assert.AreEqual(imageFrame.WidthStep(), 104);
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 100, 100, 8))
+            {
+                Assert.AreEqual(imageFrame.Width(), 100);
+                Assert.AreEqual(imageFrame.NumberOfChannels(), 1);
+                Assert.AreEqual(imageFrame.WidthStep(), 104);
+            }
         }
 
         [Test]
@@ -74,14 +77,15 @@ namespace Akihabara.Tests.Format
             };
             pixelData.CopyFrom(srcBytes);
 
-            var imageFrame = new ImageFrame(ImageFormat.Format.Sbgra, 4, 2, 16, pixelData);
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Sbgra, 4, 2, 16, pixelData))
+            {
+                Assert.AreEqual(imageFrame.Width(), 4);
+                Assert.AreEqual(imageFrame.Height(), 2);
+                Assert.False(imageFrame.IsEmpty());
 
-            Assert.AreEqual(imageFrame.Width(), 4);
-            Assert.AreEqual(imageFrame.Height(), 2);
-            Assert.False(imageFrame.IsEmpty());
-
-            var bytes = imageFrame.CopyToByteBuffer(32);
-            Assert.IsEmpty(bytes.Where((x, i) => x != srcBytes[i]));
+                var bytes = imageFrame.CopyToByteBuffer(32);
+                Assert.IsEmpty(bytes.Where((x, i) => x != srcBytes[i]));
+            }
         }
 
         [Test]
@@ -95,9 +99,10 @@ namespace Akihabara.Tests.Format
         [Test]
         public void isDisposed_ShouldReturnFalse_When_NotDisposedYet()
         {
-            var imageFrame = new ImageFrame();
-
-            Assert.False(imageFrame.IsDisposed);
+            using (var imageFrame = new ImageFrame())
+            {
+                Assert.False(imageFrame.IsDisposed);
+            }
         }
 
         [Test]
@@ -114,13 +119,15 @@ namespace Akihabara.Tests.Format
         [Test]
         public void SetToZero_ShouldSetZeroToAllBytes()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10);
-            var origBytes = imageFrame.CopyToByteBuffer(100);
-            Assert.False(origBytes.All((x) => x == 0));
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10))
+            {
+                var origBytes = imageFrame.CopyToByteBuffer(100);
+                Assert.False(origBytes.All((x) => x == 0));
 
-            imageFrame.SetToZero();
-            var bytes = imageFrame.CopyToByteBuffer(100);
-            Assert.True(bytes.All((x) => x == 0));
+                imageFrame.SetToZero();
+                var bytes = imageFrame.CopyToByteBuffer(100);
+                Assert.True(bytes.All((x) => x == 0));
+            }
         }
         #endregion
 
@@ -128,9 +135,10 @@ namespace Akihabara.Tests.Format
         [Test]
         public void SetAlignmentPaddingAreas_ShouldNotThrow()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10, 16);
-
-            Assert.DoesNotThrow(() => { imageFrame.SetAlignmentPaddingAreas(); });
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10, 16))
+            {
+                Assert.DoesNotThrow(() => { imageFrame.SetAlignmentPaddingAreas(); });
+            }
         }
         #endregion
 
@@ -138,55 +146,65 @@ namespace Akihabara.Tests.Format
         [Test]
         public void CopyToByteBuffer_ShouldReturnByteArray_When_BufferSizeIsLargeEnough()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10);
-            var normalBuffer = imageFrame.CopyToByteBuffer(100);
-            var largeBuffer = imageFrame.CopyToByteBuffer(120);
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10))
+            {
+                var normalBuffer = imageFrame.CopyToByteBuffer(100);
+                var largeBuffer = imageFrame.CopyToByteBuffer(120);
 
-            Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
+                Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
+            }
         }
 
         [Test]
         public void CopyToByteBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10);
-
-            Assert.Throws<MediapipeException>(() => { imageFrame.CopyToByteBuffer(99); });
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Gray8, 10, 10))
+            {
+                Assert.Throws<MediapipeException>(() => { imageFrame.CopyToByteBuffer(99); });
+            }
         }
 
         [Test]
         public void CopyToUshortBuffer_ShouldReturnUshortArray_When_BufferSizeIsLargeEnough()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Gray16, 10, 10);
-            var normalBuffer = imageFrame.CopyToUshortBuffer(100);
-            var largeBuffer = imageFrame.CopyToUshortBuffer(120);
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Gray16, 10, 10))
+            {
+                var normalBuffer = imageFrame.CopyToUshortBuffer(100);
+                var largeBuffer = imageFrame.CopyToUshortBuffer(120);
 
-            Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
+                Assert.IsEmpty(normalBuffer.Where((x, i) => x != largeBuffer[i]));
+            }
         }
 
         [Test]
         public void CopyToUshortBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Gray16, 10, 10);
-
-            Assert.Throws<MediapipeException>(() => { imageFrame.CopyToUshortBuffer(99); });
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Gray16, 10, 10))
+            {
+              Assert.Throws<MediapipeException>(() => { imageFrame.CopyToUshortBuffer(99); });
+            }
         }
 
         [Test]
         public void CopyToFloatBuffer_ShouldReturnFloatArray_When_BufferSizeIsLargeEnough()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Vec32F1, 10, 10);
-            var normalBuffer = imageFrame.CopyToFloatBuffer(100);
-            var largeBuffer = imageFrame.CopyToFloatBuffer(120);
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Vec32F1, 10, 10))
+            {
+                var normalBuffer = imageFrame.CopyToFloatBuffer(100);
+                var largeBuffer = imageFrame.CopyToFloatBuffer(120);
 
-            Assert.IsEmpty(normalBuffer.Where((x, i) => Math.Abs(x - largeBuffer[i]) > 1e-9));
+                Assert.IsEmpty(normalBuffer.Where((x, i) => Math.Abs(x - largeBuffer[i]) > 1e-9));
+
+            }
         }
 
         [Test]
         public void CopyToFloatBuffer_ShouldThrowException_When_BufferSizeIsTooSmall()
         {
-            var imageFrame = new ImageFrame(ImageFormat.Format.Vec32F1, 10, 10);
-
-            Assert.Throws<MediapipeException>(() => { imageFrame.CopyToFloatBuffer(99); });
+            using (var imageFrame = new ImageFrame(ImageFormat.Format.Vec32F1, 10, 10))
+            {
+                Assert.Throws<MediapipeException>(() => { imageFrame.CopyToFloatBuffer(99); });
+            }
         }
         #endregion
     }

--- a/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
+++ b/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
@@ -128,9 +128,9 @@ namespace Akihabara.Framework.ImageFormat
             return SafeNativeMethods.mp_ImageFrame__WidthStep(MpPtr);
         }
 
-        public int MutablePixelData()
+        public IntPtr MutablePixelData()
         {
-            return (int)SafeNativeMethods.mp_ImageFrame__MutablePixelData(MpPtr);
+            return SafeNativeMethods.mp_ImageFrame__MutablePixelData(MpPtr);
         }
 
         public int PixelDataSize()

--- a/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
+++ b/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
@@ -99,28 +99,26 @@ namespace Akihabara.Framework.ImageFormat
 
         public int ChannelSize()
         {
-            SafeNativeMethods.mp_ImageFrame__ChannelSize(MpPtr, out var val);
+            var code = SafeNativeMethods.mp_ImageFrame__ChannelSize(MpPtr, out var val);
 
-            // This is supposed to have a ValueOrFormatException() Function but we don't know
-            // what it implements.
             GC.KeepAlive(this);
-            return val;
+            return ValueOrFormatException(code, val);
         }
 
         public int NumberOfChannels()
         {
-            SafeNativeMethods.mp_ImageFrame__NumberOfChannels(MpPtr, out var val).Assert();
+            var code = SafeNativeMethods.mp_ImageFrame__NumberOfChannels(MpPtr, out var val);
 
             GC.KeepAlive(this);
-            return val;
+            return ValueOrFormatException(code, val);
         }
 
         public int ByteDepth()
         {
-            SafeNativeMethods.mp_ImageFrame__ByteDepth(MpPtr, out var val).Assert();
+            var code = SafeNativeMethods.mp_ImageFrame__ByteDepth(MpPtr, out var val);
 
             GC.KeepAlive(this);
-            return val;
+            return ValueOrFormatException(code, val);
         }
 
         public int WidthStep()
@@ -140,10 +138,10 @@ namespace Akihabara.Framework.ImageFormat
 
         public int PixelDataSizeStoredContiguously()
         {
-            SafeNativeMethods.mp_ImageFrame__PixelDataSizeStoredContiguously(MpPtr, out var val);
+            var code = SafeNativeMethods.mp_ImageFrame__PixelDataSizeStoredContiguously(MpPtr, out var val);
 
             GC.KeepAlive(this);
-            return val;
+            return ValueOrFormatException(code, val);
         }
 
         public void SetToZero()

--- a/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
+++ b/src/Akihabara/Framework/ImageFormat/ImageFrame.cs
@@ -21,7 +21,7 @@ namespace Akihabara.Framework.ImageFormat
 
         public ImageFrame() : base()
         {
-            UnsafeNativeMethods.mp_ImageFrame__(out var ptr);
+            UnsafeNativeMethods.mp_ImageFrame__(out var ptr).Assert();
             Ptr = ptr;
         }
 
@@ -31,7 +31,7 @@ namespace Akihabara.Framework.ImageFormat
 
         public ImageFrame(ImageFormat.Format format, int width, int height, uint alignmentBoundary) : base()
         {
-            UnsafeNativeMethods.mp_ImageFrame__ui_i_i_ui(format, width, height, alignmentBoundary, out var ptr);
+            UnsafeNativeMethods.mp_ImageFrame__ui_i_i_ui(format, width, height, alignmentBoundary, out var ptr).Assert();
             Ptr = ptr;
         }
 
@@ -47,7 +47,7 @@ namespace Akihabara.Framework.ImageFormat
                     pixelData.Ptr,
                     ReleasePixelData,
                     out var ptr
-                );
+                ).Assert();
 
                 Ptr = ptr;
             }
@@ -184,7 +184,7 @@ namespace Akihabara.Framework.ImageFormat
             {
                 fixed (T* bufferPtr = buffer)
                 {
-                    handler(MpPtr, (IntPtr)bufferPtr, bufferSize);
+                    handler(MpPtr, (IntPtr)bufferPtr, bufferSize).Assert();
                 }
             }
 


### PR DESCRIPTION
As mentioned at https://github.com/vignetteapp/Akihabara/pull/29#issuecomment-927324130 , the true error is
```txt
Process terminated. A callback was made on a garbage collected delegate of type 'Akihabara!Akihabara.Framework.ImageFormat.ImageFrame+Deleter::Invoke'.
```

This error means `ImageFrame.ReleasePixelData` (note that it is a static method) had been called but it was already disposed.
`ImageFrame.ReleasePixelData` will be called when `UnsafeNativeMethods.mp_ImageFrame__delete` is called, so we can conclude that it can be disposed when some `ImageFrame` instances are still not garbage collected.

To ensure that `ImageFrame.ReleasePixelData` won't be called after it's disposed, this PR disposes `ImageFrame` instances explicitly.

I also fixed other errors, which seem to be fixed by #29 already, though.

### Notes
This PR is based on this repo's master branch, so CI will fail, but I confirmed that if it was merged to #29, all tests would pass.
https://github.com/homuler/Akihabara/actions/runs/1280336144