### PR TITLE
Refactor `ResourceManager`

### DIFF
--- a/src/Akihabara/Native/Util/SafeResourceUtil.cs
+++ b/src/Akihabara/Native/Util/SafeResourceUtil.cs
@@ -8,8 +8,10 @@ namespace Akihabara.Native.Util
 {
     public partial class SafeNativeMethods : NativeMethods
     {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate string PathResolver(string path);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate bool ResourceProvider(string path, IntPtr output);
 
         [DllImport(MediaPipeLibrary, ExactSpelling = true)]

--- a/src/Akihabara/Util/ResourceManager.cs
+++ b/src/Akihabara/Util/ResourceManager.cs
@@ -2,30 +2,76 @@
 // See the LICENSE file in the repository root for more details.
 
 using System;
+using System.IO;
+using Akihabara.External;
 using static Akihabara.Native.Util.SafeNativeMethods;
 
 namespace Akihabara.Util
 {
+    /// <summary>
+    /// A class that handles resolving paths and obtaining resources for Mediapipe.
+    /// </summary>
+    /// <remarks>There should only be one instance of <see cref="ResourceManager"/> in the entire lifespan of an application.</remarks>
     public abstract class ResourceManager
     {
-        public abstract PathResolver PathResolver { get; }
-
-        public abstract ResourceProvider ResourceProvider { get; }
-
         private static readonly object initLock = new object();
-        private static bool isInitialized = false;
+        private static ResourceManager instance;
+        private static PathResolver pathResolver;
+        private static ResourceProvider resourceProvider;
 
         public ResourceManager() : base()
         {
             lock (initLock)
             {
-                if (isInitialized)
+                if (instance != null)
                     throw new InvalidOperationException($"{nameof(ResourceManager)} can only be initialized once.");
 
-                mp__SetCustomGlobalPathResolver__P(PathResolver);
-                mp__SetCustomGlobalResourceProvider__P(ResourceProvider);
+                // Hold instances in a variable to prevent garbage collection from cleaning it.
+                pathResolver = resolvePath;
+                resourceProvider = getResource;
 
-                isInitialized = true;
+                mp__SetCustomGlobalPathResolver__P(pathResolver);
+                mp__SetCustomGlobalResourceProvider__P(resourceProvider);
+
+                instance = this;
+            }
+        }
+
+        /// <summary>
+        /// Resolves a string path from Mediapipe to be used by <see cref="GetResource(string)"/>
+        /// </summary>
+        /// <param name="path">The path passed by Mediapipe.</param>
+        /// <returns>The resolved path.</returns>
+        protected abstract string ResolvePath(string path);
+
+        /// <summary>
+        /// Gets the resource as a <see cref="Stream"/> to be passed to Mediapipe.
+        /// </summary>
+        /// <param name="path">The path to the resource.</param>
+        /// <returns>The stream containing data to be passed to Mediapipe.</returns>
+        protected abstract Stream GetResource(string path);
+
+        private static string resolvePath(string path) => instance.ResolvePath(path);
+
+        private static bool getResource(string path, IntPtr dest)
+        {
+            try
+            {
+                string resolved = instance.ResolvePath(path);
+                var resource = instance.GetResource(resolved);
+
+                using var memory = new MemoryStream();
+                resource.CopyTo(memory);
+
+                using var source = new StdString(memory.ToArray());
+                source.Swap(new StdString(dest, false));
+
+                return true;
+            }
+            catch (Exception)
+            {
+                // TODO: Handle errors
+                return false;
             }
         }
     }


### PR DESCRIPTION
This refactors `ResourceManager` to simplify creating derived classes for it as well as moving possible common logic to static methods.