### PR TITLE
add hashbang to build.py; mark as executable

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import glob
 import os


### PR DESCRIPTION
Just a quick fix to keep build.py from being mangled by interactive shells